### PR TITLE
fix: return single dict instead of list for /status/models/{model_name}

### DIFF
--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -1126,7 +1126,11 @@ class ModelSingle(Resource):
         '''
         self.args = self.get_parser.parse_args()
         models_ret = database.get_available_models(model_name)
-        return (models_ret,200)
+        if len(models_ret) > 1:
+            logger.warning("More than one model returned for model_name: " + model_name)
+
+        return_value = models_ret[0]
+        return (return_value,200)
 
 
 class HordeLoad(Resource):


### PR DESCRIPTION
The documented return type is `response_model_active_model`, where as currently it returns a `list` of said types. As far as I can see, the call to `get_available_models()` would always return a list of one, giving a potentially confusing (and undocumented) response, but I am unsure as to the exact intention here.