### PR TITLE
feat: pixel/step limit for image gen on shared keys

### DIFF
--- a/horde/apis/models/v2.py
+++ b/horde/apis/models/v2.py
@@ -194,6 +194,8 @@ class Models:
             "kudos": fields.Integer(min=-1, max=50000000, default=5000, required=False, description="The Kudos limit assigned to this key. If -1, then anyone with this key can use an unlimited amount of kudos from this account."),
             "expiry": fields.Integer(min=-1, default=-1, example=30, required=False, description="The amount of days after which this key will expire. If -1, this key will not expire"),
             "name": fields.String(min_length=3, max_length=255, required=False, example="Mutual Aid", description="A descriptive name for this key"),
+            "max_image_pixels": fields.Integer(min=-1, max=4194304, default=-1, required=False, description="The maximum amount of image pixels this key can generate per job. -1 means unlimited."),
+            "max_image_steps": fields.Integer(min=-1, max=500, default=-1, required=False, description="The maximum amount of image steps this key can use per job. -1 means unlimited."),
         })
 
         self.response_model_sharedkey_details = api.model('SharedKeyDetails', {
@@ -202,6 +204,8 @@ class Models:
             "kudos": fields.Integer(description="The Kudos limit assigned to this key"),
             "expiry": fields.DateTime(dt_format='rfc822',description="The date at which this API key will expire."),
             "utilized": fields.Integer(description="How mych kudos has been utilized via this shared key until now."),
+            "max_image_pixels": fields.Integer(description="The maximum amount of image pixels this key can generate per job. -1 means unlimited."),
+            "max_image_steps": fields.Integer(description="The maximum amount of image steps this key can use per job. -1 means unlimited."),
         })
 
         #TODO: Obsolete

--- a/horde/apis/v2/stable.py
+++ b/horde/apis/v2/stable.py
@@ -137,6 +137,14 @@ class ImageAsyncGenerate(GenerateTemplate):
                 "First ensure it provides a proper name and contact details. "
                 "Then contact us on Discord to discuss the issue it's creating."
             )
+        if self.sharedkey:
+            requested_total_pixels = self.args.params["height"] * self.args.params["width"] * self.params["n"]
+            requested_steps = self.args.params["steps"]
+
+            is_in_limit, fail_message = self.sharedkey.is_job_within_limits(image_pixels = requested_total_pixels, image_steps = requested_steps)
+            if not is_in_limit:
+                raise e.BadRequest(fail_message)
+        
 
     # We split this into its own function, so that it may be overriden
     def initiate_waiting_prompt(self):

--- a/horde/classes/base/user.py
+++ b/horde/classes/base/user.py
@@ -79,6 +79,8 @@ class UserSharedKey(db.Model):
     name = db.Column(db.String(255), nullable=True)
     utilized = db.Column(db.BigInteger, default=0, nullable=False)
     waiting_prompts = db.relationship("WaitingPrompt", back_populates="sharedkey", passive_deletes=True, cascade="all, delete-orphan")
+    max_image_pixels = db.Column(db.Integer, default=-1, nullable=False)
+    max_image_steps = db.Column(db.Integer, default=-1, nullable=False)
 
     @logger.catch(reraise=True)
     def get_details(self):
@@ -88,6 +90,8 @@ class UserSharedKey(db.Model):
             "kudos": self.kudos,
             "expiry": self.expiry,
             "utilized": self.utilized,
+            "max_image_pixels": self.max_image_pixels,
+            "max_image_steps": self.max_image_steps
         }
         return ret_dict
 
@@ -109,6 +113,35 @@ class UserSharedKey(db.Model):
             return False,"This shared key has expired"
         else:
             return True, None
+
+    def is_job_within_limits(self, 
+        *, 
+        image_pixels: int = None, 
+        image_steps: int = None
+    ) -> tuple[bool, str | None]:
+        """Checks if the job is within the limits of the shared key
+
+        Args:
+            image_pixels (int, optional): The number of requested pixels. Defaults to None.
+            image_steps (int, optional): The number of requested steps. Defaults to None.
+
+        Returns:
+            tuple[bool, str | None]: Whether the job is within the limits and a message if it is not
+        """
+        if image_pixels is None and image_steps is None:
+            return True, None
+        
+        if self.max_image_pixels != -1:
+            if image_pixels > self.max_image_pixels:
+                return False, f"This shared key is limited to {self.max_image_pixels} pixels per job. You requested {image_pixels} pixels."
+                
+        if self.max_image_steps != -1:    
+            if image_steps > self.max_image_steps:
+                return False, f"This shared key is limited to {self.max_image_steps} steps per job. You requested {image_steps} steps."
+
+        return True, None
+
+    
 
 class User(db.Model):
     __tablename__ = "users"


### PR DESCRIPTION
Extends the shared key feature to optionally limit the total number of pixels or steps that can be created in a single job. -1 (the default) indicates unlimited.

- `GET`, `PUT`, `PATCH` verbs for the `/sharedkeys/` endpoint all support their expected functions, and the relevant api models also report the new payloads/return info.
- The db will require an update to support this change:
```python
class UserSharedKey(db.Model):
...
    max_image_pixels = db.Column(db.Integer, default=-1, nullable=False)
    max_image_steps = db.Column(db.Integer, default=-1, nullable=False)
...
```
- I can confirm this runs locally and operates as I expect in limited testing.