### PR TITLE
fix: allow negative LoRa clip strength

### DIFF
--- a/horde/apis/models/stable_v2.py
+++ b/horde/apis/models/stable_v2.py
@@ -43,7 +43,7 @@ class ImageModels(v2.Models):
         self.input_model_loras = api.model('ModelPayloadLorasStable', {
             'name': fields.String(required=True, example="GlowingRunesAIV6", description="The exact name or CivitAI ID of the LoRa.", unique=True, min_length = 1, max_length = 255),
             'model': fields.Float(required=False, default=1.0, min=-5.0, max=5.0, description="The strength of the LoRa to apply to the SD model."), 
-            'clip': fields.Float(required=False, default=1.0, min=0.0, max=5.0, description="The strength of the LoRa to apply to the clip model."), 
+            'clip': fields.Float(required=False, default=1.0, min=-5.0, max=5.0, description="The strength of the LoRa to apply to the clip model."), 
             'inject_trigger': fields.String(required=False, min_length = 1, max_length = 30, description="If set, will try to discover a trigger for this LoRa which matches or is similar to this string and inject it into the prompt. If 'any' is specified it will be pick the first trigger."),
         })
         self.input_model_tis = api.model('ModelPayloadTextualInversionsStable', {


### PR DESCRIPTION
TLDR: Sets the LoRa `clip` weight constraints to match the `model` weight constraints.

Hordelib 1.6.2 already supports negative `model`/`clip` strengths for LoRas. The current range is `(-5, 5)` for model strength on the API, but the clip strength range is `(0, 5)`. Hordelib will dutifully use a clip strength as low as -10 (a limit imposed by comfyui), but to minimize potentially wasteful results (-10 invariably destroys the image), I am recommending only that we bring the `clip` and `model` strength values in line with each other.