### PR TITLE
fix: shared key patch endpoint typo corrected

### DIFF
--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -1774,7 +1774,7 @@ class SharedKeySingle(Resource):
             raise e.InvalidAPIKey("patch sharedkey")
         if sharedkey.user_id != user.id:
             raise e.Forbidden(f"Shared Key {sharedkey.id} belongs to {sharedkey.user.get_unique_alias()} and not to {user.get_unique_alias()}.")
-        if not self.args.expiry and not self.args.kudos and not self.arg.name:
+        if not self.args.expiry and not self.args.kudos and not self.args.name:
             raise e.NoValidActions("No shared key modification selected!")
         if self.args.expiry is not None:
             if self.args.expiry == -1:

--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -1774,7 +1774,10 @@ class SharedKeySingle(Resource):
             raise e.InvalidAPIKey("patch sharedkey")
         if sharedkey.user_id != user.id:
             raise e.Forbidden(f"Shared Key {sharedkey.id} belongs to {sharedkey.user.get_unique_alias()} and not to {user.get_unique_alias()}.")
-        if not self.args.expiry and not self.args.kudos and not self.args.name:
+        no_valid_actions = self.args.expiry is None and self.args.kudos is None and self.args.name is None
+        no_valid_limit_actions = self.args.max_image_pixels is None and self.args.max_image_steps is None and self.args.max_text_tokens is None
+
+        if no_valid_actions and no_valid_limit_actions:
             raise e.NoValidActions("No shared key modification selected!")
         if self.args.expiry is not None:
             if self.args.expiry == -1:


### PR DESCRIPTION
Fixes a bug in the shared key PATCH endpoint, and as @amiantos pointed out, it being a truthy check is faulty given valid values of some of those fields.

I am following their recommendation in the following way: 
```python
no_valid_actions = self.args.expiry is None and self.args.kudos is None and self.args.name is None
no_valid_limit_actions = self.args.max_image_pixels is None and self.args.max_image_steps is None and self.args.max_text_tokens is None

if no_valid_actions and no_valid_limit_actions:
    raise e.NoValidActions("No shared key modification selected!")
```