### PR TITLE
This commit adds support for the stop_sequence parameter

### DIFF
--- a/horde/apis/models/kobold_v2.py
+++ b/horde/apis/models/kobold_v2.py
@@ -46,6 +46,7 @@ class TextModels(v2.Models):
             'typical': fields.Float(description="Typical sampling value.", min=0.0, max=1.0),
             'sampler_order': fields.List(fields.Integer(description="Array of integers representing the sampler order to be used.")),
             'use_default_badwordsids': fields.Boolean(example=True,description="When True, uses the default KoboldAI bad word IDs."),
+            'stop_sequence': fields.List(fields.String(description="An array of string sequences whereby the model will stop generating further tokens. The returned text WILL contain the stop sequence.")),
         })
         self.response_model_generation_payload = api.inherit('ModelPayloadKobold', self.root_model_generation_payload_kobold, {
             'prompt': fields.String(description="The prompt which will be sent to KoboldAI to generate the text."),

--- a/horde/apis/v2/kobold.py
+++ b/horde/apis/v2/kobold.py
@@ -103,6 +103,13 @@ class TextAsyncGenerate(GenerateTemplate):
             raise e.BadRequest("You cannot request more tokens than your context length.")
         if "sampler_order" in self.params and len(set(self.params["sampler_order"])) < 7:
             raise e.BadRequest("When sending a custom sampler order, you need to specify all possible samplers in the order")
+        if "stop_sequence" in self.params:
+            stop_seqs = set(self.params["stop_sequence"])
+            if len(stop_seqs) > 16:
+                raise e.BadRequest("Too many stop sequences specified (max allowed is 16).")
+            for seq in stop_seqs:
+                if len(seq) > 512:
+                    raise e.BadRequest("A stop sequence exceeds maximum allowed length (max 512 chars).")
 
 
     def get_hashed_params_dict(self):

--- a/horde/apis/v2/kobold.py
+++ b/horde/apis/v2/kobold.py
@@ -107,9 +107,11 @@ class TextAsyncGenerate(GenerateTemplate):
             stop_seqs = set(self.params["stop_sequence"])
             if len(stop_seqs) > 16:
                 raise e.BadRequest("Too many stop sequences specified (max allowed is 16).")
+            total_stop_seq_len = 0
             for seq in stop_seqs:
-                if len(seq) > 512:
-                    raise e.BadRequest("A stop sequence exceeds maximum allowed length (max 512 chars).")
+                total_stop_seq_len += len(seq)
+            if total_stop_seq_len > 2000:
+                raise e.BadRequest("Your total stop sequence length exceeds the allowed limit (2000 chars).")
 
 
     def get_hashed_params_dict(self):


### PR DESCRIPTION
This commit finally adds support for the `stop_sequence` parameter for the text generation payload in Horde. The `stop_sequence` is an array of stopping strings that indicates to the backend when generation should be prematurely halted. As it is already integrated into Kobold as part of the submitted payload, no modification to the scribe/worker should be necessary. 

Do review, thanks!