### PR TITLE
docs: place artbot first in web ui list

### DIFF
--- a/index_stable.md
+++ b/index_stable.md
@@ -42,8 +42,8 @@ First [Register an account](/register) which will generate for you an API key. S
 
 * We provide [a client interface](https://dbzer0.itch.io/lucid-creations) requiring no installation and no technical expertise
 * We have also a few dedicated Web UIs with even less requirements:
-    * [Stable UI](https://aqualxx.github.io/stable-ui/)
     * [Art Bot](https://tinybots.net/artbot)
+    * [Stable UI](https://aqualxx.github.io/stable-ui/)
     * [AAAI UI](https://artificial-art.eu/)
 * There are also mobile apps:
     * AI Painter ([iOS](https://apps.apple.com/hk/app/%E6%A9%9F%E7%95%AB%E5%B8%AB-%E5%B0%88%E6%A5%AD%E7%9A%84ai%E7%B9%AA%E7%95%ABapp/id1644645946) + [Android](https://play.google.com/store/apps/details?id=wkygame.ai.all.in.one))


### PR DESCRIPTION
I think it is a fair assessment that among the dedicated web UIs that ArtBot is the most feature complete and best maintained. This PR simply places ArtBot at the top of the web UI list, which I feel the top option may be the more likely one to be clicked. 

This is in direct response to the continued appearance of users reporting problems with stable UI in the discord server, which I and others invariably point them to ArtBot instead. A number of these users were directed to Stable UI via the main page, and as such I feel it is appropriate to bump ArtBot to the top of the list.