### PR TITLE
feat: show requesting user in log on job submit

### DIFF
--- a/horde/classes/base/processing_generation.py
+++ b/horde/classes/base/processing_generation.py
@@ -95,8 +95,8 @@ class ProcessingGeneration(db.Model):
         else:
             self.worker.record_contribution(raw_things = self.wp.things, kudos = kudos, things_per_sec = things_per_sec)
             self.wp.record_usage(raw_things = self.wp.things, kudos = self.adjust_user_kudos(kudos))
-            logger.info(f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id} \
-                (requesting user {self.wp.user.get_unique_alias()} [{self.wp.ipaddr}])")
+            logger.info(f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id} "
+                f" (requesting user {self.wp.user.get_unique_alias()} [{self.wp.ipaddr}])")
 
     def adjust_user_kudos(self, kudos):
         if self.censored:

--- a/horde/classes/base/processing_generation.py
+++ b/horde/classes/base/processing_generation.py
@@ -95,7 +95,8 @@ class ProcessingGeneration(db.Model):
         else:
             self.worker.record_contribution(raw_things = self.wp.things, kudos = kudos, things_per_sec = things_per_sec)
             self.wp.record_usage(raw_things = self.wp.things, kudos = self.adjust_user_kudos(kudos))
-            logger.info(f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id}")
+            logger.info(f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id} \
+                (requesting user {self.wp.user.get_unique_alias()} [{self.wp.ipaddr}])")
 
     def adjust_user_kudos(self, kudos):
         if self.censored:

--- a/horde/classes/base/processing_generation.py
+++ b/horde/classes/base/processing_generation.py
@@ -95,8 +95,12 @@ class ProcessingGeneration(db.Model):
         else:
             self.worker.record_contribution(raw_things = self.wp.things, kudos = kudos, things_per_sec = things_per_sec)
             self.wp.record_usage(raw_things = self.wp.things, kudos = self.adjust_user_kudos(kudos))
-            logger.info(f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id} "
-                f" (requesting user {self.wp.user.get_unique_alias()} [{self.wp.ipaddr}])")
+            log_string = f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id} " + \
+                f" (requesting user {self.wp.user.get_unique_alias()} [{self.wp.ipaddr}])"
+
+            if self.wp.censor_nsfw is not True:
+                log_string += f" (censored: {self.censored})"
+            logger.info(log_string)
 
     def adjust_user_kudos(self, kudos):
         if self.censored:

--- a/horde/classes/base/processing_generation.py
+++ b/horde/classes/base/processing_generation.py
@@ -97,9 +97,6 @@ class ProcessingGeneration(db.Model):
             self.wp.record_usage(raw_things = self.wp.things, kudos = self.adjust_user_kudos(kudos)) 
             log_string = f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id} "
             log_string += f" (requesting user {self.wp.user.get_unique_alias()} [{self.wp.ipaddr}])"
-
-            if self.wp.censor_nsfw is not True:
-                log_string += f" (censored: {self.censored})"
             logger.info(log_string)
 
     def adjust_user_kudos(self, kudos):

--- a/horde/classes/base/processing_generation.py
+++ b/horde/classes/base/processing_generation.py
@@ -94,9 +94,9 @@ class ProcessingGeneration(db.Model):
             logger.info(f"Fake{cancel_txt} Generation {self.id} worth {self.kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id}")
         else:
             self.worker.record_contribution(raw_things = self.wp.things, kudos = kudos, things_per_sec = things_per_sec)
-            self.wp.record_usage(raw_things = self.wp.things, kudos = self.adjust_user_kudos(kudos))
-            log_string = f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id} " + \
-                f" (requesting user {self.wp.user.get_unique_alias()} [{self.wp.ipaddr}])"
+            self.wp.record_usage(raw_things = self.wp.things, kudos = self.adjust_user_kudos(kudos)) 
+            log_string = f"New{cancel_txt} Generation {self.id} worth {kudos} kudos, delivered by worker: {self.worker.name} for wp {self.wp.id} "
+            log_string += f" (requesting user {self.wp.user.get_unique_alias()} [{self.wp.ipaddr}])"
 
             if self.wp.censor_nsfw is not True:
                 log_string += f" (censored: {self.censored})"


### PR DESCRIPTION
This will help minimize the amount of extracting and client-side relating of messages in the logs. This will make it easier for me to investigate a user at glance without having to download and parse the logs.