### PR TITLE
feat: support cfg scales to 0.01 precision

### DIFF
--- a/horde/apis/models/stable_v2.py
+++ b/horde/apis/models/stable_v2.py
@@ -61,7 +61,7 @@ class ImageModels(v2.Models):
         })        
         self.root_model_generation_payload_stable = api.model('ModelPayloadRootStable', {
             'sampler_name': fields.String(required=False, default='k_euler_a',enum=["k_lms", "k_heun", "k_euler", "k_euler_a", "k_dpm_2", "k_dpm_2_a", "k_dpm_fast", "k_dpm_adaptive", "k_dpmpp_2s_a", "k_dpmpp_2m", "dpmsolver", "k_dpmpp_sde", "DDIM"]), 
-            'cfg_scale': fields.Float(required=False,default=7.5, min=0, max=100, multiple=0.5), 
+            'cfg_scale': fields.Float(required=False,default=7.5, min=0, max=100, multiple=0.01), 
             'denoising_strength': fields.Float(required=False, example=0.75, min=0.01, max=1.0), 
             'seed': fields.String(required=False, example="The little seed that could", description="The seed to use to generate this request. You can pass text as well as numbers."),
             'height': fields.Integer(required=False, default=512, description="The height of the image to generate.", min=64, max=3072, multiple=64),


### PR DESCRIPTION
Following up on the [discussion in discord](https://discord.com/channels/781145214752129095/1182918213567270952/1183480524354900028):

- The LCM LoRa, and probably other features/model formats, work best with low (0.0-1.0) CFG scales.
- Presently, the horde only allows CFG scales [which are multiples of 0.5.](https://github.com/Haidra-Org/AI-Horde/blob/2155d4866c5b1ef72c2280fdadc378499aecae5a/horde/apis/models/stable_v2.py#L64)
  - I suspect this current state of affairs is rooted in a time when a different backend for inference was being used, as there is no technical reason to require values divisible by 0.5 for ComfyUI right now.  
- This change allows the CFG scale to include precision down to 0.01.