### PR TITLE
fix: handle cfg_scale precision w/o changing datatype

### DIFF
--- a/horde/apis/models/stable_v2.py
+++ b/horde/apis/models/stable_v2.py
@@ -61,7 +61,7 @@ class ImageModels(v2.Models):
         })        
         self.root_model_generation_payload_stable = api.model('ModelPayloadRootStable', {
             'sampler_name': fields.String(required=False, default='k_euler_a',enum=["k_lms", "k_heun", "k_euler", "k_euler_a", "k_dpm_2", "k_dpm_2_a", "k_dpm_fast", "k_dpm_adaptive", "k_dpmpp_2s_a", "k_dpmpp_2m", "dpmsolver", "k_dpmpp_sde", "DDIM"]), 
-            'cfg_scale': fields.Float(required=False,default=7.5, min=0, max=100, multiple=0.01), 
+            'cfg_scale': fields.Float(required=False,default=7.5, min=0, max=100), 
             'denoising_strength': fields.Float(required=False, example=0.75, min=0.01, max=1.0), 
             'seed': fields.String(required=False, example="The little seed that could", description="The seed to use to generate this request. You can pass text as well as numbers."),
             'height': fields.Integer(required=False, default=512, description="The height of the image to generate.", min=64, max=3072, multiple=64),

--- a/horde/apis/v2/stable.py
+++ b/horde/apis/v2/stable.py
@@ -155,6 +155,19 @@ class ImageAsyncGenerate(GenerateTemplate):
             )
             if upscaler_count > 1:
                 raise e.UnsupportedModel("Cannot use more than 1 upscaler at a time.")
+
+            cfg_scale = self.args.params.get("cfg_scale")
+            if cfg_scale is not None:
+                try:                
+                    rounded_cfg_scale = round(cfg_scale, 2)
+                    if rounded_cfg_scale != cfg_scale:
+                        raise e.BadRequest("cfg_scale must be rounded to 2 decimal places")
+                except (TypeError, ValueError):
+                    logger.warning(f"Invalid cfg_scale: {cfg_scale} for user {self.username} when it should be already validated.")
+                    raise e.BadRequest("cfg_scale must be a valid number")
+                    
+                
+
         if self.args["Client-Agent"] in ["My-Project:v0.0.1:My-Contact"]:
             raise e.BadRequest(
                 "This Client-Agent appears badly designed and is causing too many warnings. "


### PR DESCRIPTION
Due to the field being a floating point number, and the flask mechanism not adequately supporting `multiple` for that datatype for our purposes, I have [removed the constraint from the API model](https://github.com/Haidra-Org/AI-Horde/blob/c3988aa106aeabdba8ac99de70cda737c77098b6/horde/apis/models/stable_v2.py#L64) and [added a simple rounding check](https://github.com/Haidra-Org/AI-Horde/blob/c3988aa106aeabdba8ac99de70cda737c77098b6/horde/apis/v2/stable.py#L159C29-L159C29) which should give the intended behavior for floating point values which are sent/represented as greater than 2 decimals.