### PR TITLE
fix: show working lora example

### DIFF
--- a/horde/apis/models/stable_v2.py
+++ b/horde/apis/models/stable_v2.py
@@ -46,7 +46,7 @@ class ImageModels(v2.Models):
             'shared': fields.Boolean(description="If True, These images have been shared with LAION."),
         })
         self.input_model_loras = api.model('ModelPayloadLorasStable', {
-            'name': fields.String(required=True, example="GlowingRunesAIV6", description="The exact name or CivitAI ID of the LoRa.", unique=True, min_length = 1, max_length = 255),
+            'name': fields.String(required=True, example="Magnagothica", description="The exact name or CivitAI Model Page ID of the LoRa. If is_version is true, this should be the CivitAI version ID.", unique=True, min_length = 1, max_length = 255),
             'model': fields.Float(required=False, default=1.0, min=-5.0, max=5.0, description="The strength of the LoRa to apply to the SD model."), 
             'clip': fields.Float(required=False, default=1.0, min=-5.0, max=5.0, description="The strength of the LoRa to apply to the clip model."), 
             'inject_trigger': fields.String(required=False, min_length = 1, max_length = 30, description="If set, will try to discover a trigger for this LoRa which matches or is similar to this string and inject it into the prompt. If 'any' is specified it will be pick the first trigger."),


### PR DESCRIPTION
The API docs for LoRa usage show `GlowingRunesAIV6` currently as an example. This LoRa was deleted and readded under a different name and as such is now invalid as a value currently. This PR updates the value to one uploaded by @db0 (Magnagothica) and slightly clarifies the API doc field description.

This will also resolve https://github.com/Haidra-Org/horde-sdk/issues/119 as a consequence (automatically; the SDK issue is due to the test payloads/responses relying on the API docs to mock this field) after this change is live and the next SDK release happens.

Thanks @daveschumaker for pointing this out.