### PR TITLE
Update API models to not say 'image' in text gen fields.

### DIFF
--- a/horde/apis/models/kobold_v2.py
+++ b/horde/apis/models/kobold_v2.py
@@ -23,6 +23,9 @@ class TextModels(v2.Models):
             'ref': fields.String(required=False, description="Optionally a reference for the metadata (e.g. a lora ID)", max_length = 255),
         })
         self.response_model_generation_result = api.inherit('GenerationKobold', self.response_model_generation_result, {
+            'worker_id': fields.String(title="Worker ID", description="The UUID of the worker which generated this text."),
+            'worker_name': fields.String(title="Worker Name", description="The name of the worker which generated this text."),
+            'model': fields.String(title="Generation Model", description="The model which generated this text."),
             'text': fields.String(title="Generated Text", description="The generated text.", min_length = 0),
             'seed': fields.Integer(title="Generation Seed", description="The seed which generated this text.", default=0),
             'gen_metadata': fields.List(fields.Nested(self.model_job_metadata, skip_none=True)),

--- a/horde/apis/models/stable_v2.py
+++ b/horde/apis/models/stable_v2.py
@@ -35,6 +35,9 @@ class ImageModels(v2.Models):
             'ref': fields.String(required=False, description="Optionally a reference for the metadata (e.g. a lora ID)", max_length = 255),
         })
         self.response_model_generation_result = api.inherit('GenerationStable', self.response_model_generation_result, {
+            'worker_id': fields.String(title="Worker ID", description="The UUID of the worker which generated this image."),
+            'worker_name': fields.String(title="Worker Name", description="The name of the worker which generated this image."),
+            'model': fields.String(title="Generation Model", description="The model which generated this image."),
             'img': fields.String(title="Generated Image", description="The generated image as a Base64-encoded .webp file."),
             'seed': fields.String(title="Generation Seed", description="The seed which generated this image."),
             'id': fields.String(title="Generation ID", description="The ID for this image."),

--- a/horde/apis/models/v2.py
+++ b/horde/apis/models/v2.py
@@ -66,9 +66,6 @@ class Models:
             'count': fields.Integer(description="How many of workers in this horde are running this model."),
         })
         self.response_model_generation_result = api.model('Generation', {
-            'worker_id': fields.String(title="Worker ID", description="The UUID of the worker which generated this image."),
-            'worker_name': fields.String(title="Worker Name", description="The name of the worker which generated this image."),
-            'model': fields.String(title="Generation Model", description="The model which generated this image."),
             'state': fields.String(title="Generation State", required=True, default='ok', enum=["ok", "censored"], description="OBSOLETE (Use the gen_metadata field). The state of this generation."),
         })
         self.response_model_wp_status_full = api.inherit('RequestStatus', self.response_model_wp_status_lite, {


### PR DESCRIPTION
I hope this actually wprks properly, since I certainly can't test it on my tablet. If not, it should be an easy fix for someone who actually knows what they're doing...

Credit: Fripe pointed this out [here](https://discord.com/channels/781145214752129095/1042786389474947112/1198245388361142292), and I figured it'd be an easy fix. Then when I went to look, I remembered that the api reference is generated :(
