### PR TITLE
fix: Various API model fixes

### DIFF
--- a/horde/apis/models/kobold_v2.py
+++ b/horde/apis/models/kobold_v2.py
@@ -377,8 +377,8 @@ class TextModels(v2.Models):
             },
         )
 
-        self.response_model_single_period_total_img_stat = api.model(
-            "SinglePeriodImgStat",
+        self.response_model_single_period_total_txt_stat = api.model(
+            "SinglePeriodTxtStat",
             {
                 "requests": fields.Integer(description="The amount of text requests generated during this period."),
                 "tokens": fields.Integer(description="The amount of tokens generated during this period."),
@@ -388,11 +388,11 @@ class TextModels(v2.Models):
         self.response_model_stats_img_totals = api.model(
             "StatsTxtTotals",
             {
-                "minute": fields.Nested(self.response_model_single_period_total_img_stat),
-                "hour": fields.Nested(self.response_model_single_period_total_img_stat),
-                "day": fields.Nested(self.response_model_single_period_total_img_stat),
-                "month": fields.Nested(self.response_model_single_period_total_img_stat),
-                "total": fields.Nested(self.response_model_single_period_total_img_stat),
+                "minute": fields.Nested(self.response_model_single_period_total_txt_stat),
+                "hour": fields.Nested(self.response_model_single_period_total_txt_stat),
+                "day": fields.Nested(self.response_model_single_period_total_txt_stat),
+                "month": fields.Nested(self.response_model_single_period_total_txt_stat),
+                "total": fields.Nested(self.response_model_single_period_total_txt_stat),
             },
         )
 

--- a/horde/apis/models/v2.py
+++ b/horde/apis/models/v2.py
@@ -1474,7 +1474,7 @@ class Models:
         self.model_extra_source_images = api.model(
             "ExtraSourceImage",
             {
-                "image": fields.String(description="The Base64-encoded webp to use for further processing."),
+                "image": fields.String(description="The Base64-encoded webp to use for further processing.", min_length=1),
                 "strength": fields.Float(description="Optional field, determining the strength to use for the processing", default=1.0),
             },
         )

--- a/horde/apis/models/v2.py
+++ b/horde/apis/models/v2.py
@@ -932,6 +932,13 @@ class Models:
                     example=False,
                     description="This is an education account used schools and universities.",
                 ),
+                "customizer": fields.Boolean(
+                    example=False,
+                    description=(
+                        "When set to true, the user will be able to serve custom Stable Diffusion models "
+                        f"which do not exist in the Official {horde_title} Model Reference."
+                    ),
+                ),
                 "special": fields.Boolean(
                     example=False,
                     description="(Privileged) This user has been given the Special role.",

--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -1734,21 +1734,21 @@ class HordeModes(Resource):
     parser = reqparse.RequestParser()
     parser.add_argument("apikey", type=str, required=True, help="The Admin API key.", location="headers")
     parser.add_argument(
-        "maintenance",
+        "maintenance_mode",
         type=bool,
         required=False,
         help="Start or stop maintenance mode.",
         location="json",
     )
     parser.add_argument(
-        "invite_only",
+        "invite_only_mode",
         type=bool,
         required=False,
         help="Start or stop worker invite-only mode.",
         location="json",
     )
     parser.add_argument(
-        "raid",
+        "raid_mode",
         type=bool,
         required=False,
         help="Start or stop raid mode.",
@@ -1776,10 +1776,10 @@ class HordeModes(Resource):
             raise e.InvalidAPIKey("Admin action: " + "PUT HordeModes")
         ret_dict = {}
         cfg = settings.get_settings()
-        if self.args.maintenance is not None:
+        if self.args.maintenance_mode is not None:
             if not os.getenv("ADMINS") or admin.get_unique_alias() not in json.loads(os.getenv("ADMINS")):
                 raise e.NotAdmin(admin.get_unique_alias(), "PUT HordeModes")
-            cfg.maintenance = self.args.maintenance
+            cfg.maintenance = self.args.maintenance_mode
             if cfg.maintenance:
                 logger.critical(f"{horde_title} entered maintenance mode")
                 for wp in database.get_all_active_wps():
@@ -1794,15 +1794,15 @@ class HordeModes(Resource):
         #         wp.abort_for_maintenance()
         #     database.shutdown(self.args.shutdown)
         #     ret_dict["maintenance_mode"] = settings.maintenance
-        if self.args.invite_only is not None:
+        if self.args.invite_only_mode is not None:
             if not admin.moderator:
                 raise e.NotModerator(admin.get_unique_alias(), "PUT HordeModes")
-            cfg.invite_only = self.args.invite_only
+            cfg.invite_only = self.args.invite_only_mode
             ret_dict["invite_only_mode"] = cfg.invite_only
-        if self.args.raid is not None:
+        if self.args.raid_mode is not None:
             if not admin.moderator:
                 raise e.NotModerator(admin.get_unique_alias(), "PUT HordeModes")
-            cfg.raid = self.args.raid
+            cfg.raid = self.args.raid_mode
             ret_dict["raid_mode"] = cfg.raid
         if not len(ret_dict):
             raise e.NoValidActions("No mod change selected!", rc="NoHordeModSelected")

--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -1619,6 +1619,7 @@ class ModelSingle(Resource):
         models.response_model_active_model,
         code=200,
         description="Lists specific model stats",
+        as_list=True,
     )
     def get(self, model_name="stable_diffusion"):
         """Returns all the statistics of a specific model in this horde"""

--- a/horde/classes/base/user.py
+++ b/horde/classes/base/user.py
@@ -845,6 +845,7 @@ class User(db.Model):
             "account_age": (datetime.utcnow() - self.created).total_seconds(),
             "service": self.service,
             "education": self.education,
+            "customizer": self.customizer,
             # unnecessary information, since the workers themselves wil be visible
             # "public_workers": self.public_workers,
         }

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,3 +3,5 @@ black==24.2.0
 ruff==0.3.1
 tox~=4.14.1
 horde_sdk>=0.7.29
+
+pytest-asyncio


### PR DESCRIPTION
In the course of expanding the SDK, certain inconsistencies were made apparent. This PR serves to correct the issues.

- [fix: use SinglePeriodTxtStat for text totals stat endpoint](https://github.com/Haidra-Org/AI-Horde/pull/403/commits/f291061949b32db60d66d04361d2eb86ac9a2f1a)
  - Previously, probably due to copy and pasting, the `/v2/stats/text/totals` endpoint published in the swagger doc that returned elements were of type `SinglePeriodImgStat`, which could be a source of confusion when consuming the swagger doc. `/v2/stats/img/totals` returns elements with different attributes, so this PR hopefully will clarify that the two endpoints return two different types of objects.
- [fix: set min_length for image attr in ExtraSourceImage](https://github.com/Haidra-Org/AI-Horde/pull/403/commits/6a8608f558341a000460ad44bb6f88ea0764b2cb)
  - This accurately reflects that it is a required field for creating a `ExtraSourceImage`
- [fix: include customizer on user info endpoints](https://github.com/Haidra-Org/AI-Horde/pull/403/commits/f6653bfbea66b1255f921ba7e6ad33b18c68ef4d)
- [fix: match PUT horde mode arg names to ret. payload](https://github.com/Haidra-Org/AI-Horde/pull/403/commits/26ba188b460f1bb12798831c9e2387de4976c7ef)
  - The input parameters names did not match the returned fields for the `PUT` action of `/v2/status/modes`. For clarity (and ease of object/model reuse client-side) I am changing the payload argument names to match. This is a breaking change, but as only admins (i.e., you) can use it, I think it is safe to do so.
- [fix: match apidoc for ModelSingle to actual return type](https://github.com/Haidra-Org/AI-Horde/pull/403/commits/d3a7b73cc1bde7056a87e528a5a1d6a3d81025a7)
  - While this endpoint *should* return a single value, in reality it does (and probably always has) return a list of a single element instead. Because changing the actual return value constitutes a breaking change, I recommend simply fixing the API doc for now and changing it to the (presumably) intended type when we go to `/v3/`.
- [ci: allow SDK async tests to run](https://github.com/Haidra-Org/AI-Horde/pull/403/commits/46c1bb5fdafc1156126464d3ef0bcc0bc4529549)
  - Forthcoming AI-Horde CI SDK-based tests will require `pytest-asyncio` as a reqs.dev.txt dependency. 