### PR TITLE
fix: use the correct response model for text async

### DIFF
--- a/horde/apis/models/kobold_v2.py
+++ b/horde/apis/models/kobold_v2.py
@@ -238,9 +238,9 @@ class TextModels(v2.Models):
             },
         )
         self.response_model_job_pop = api.model(
-            "GenerationPayload",
+            "GenerationPayloadKobold",
             {
-                "payload": fields.Nested(self.response_model_generation_payload, skip_none=True),
+                "payload": fields.Nested(self.root_model_generation_payload_kobold, skip_none=True),
                 "id": fields.String(description="The UUID for this text generation."),
                 "ids": fields.List(
                     fields.String(


### PR DESCRIPTION
This corrects the API doc for the text async generate endpoint. 