### PR TITLE
expand api docs by default

### DIFF
--- a/horde/apis/apiv2.py
+++ b/horde/apis/apiv2.py
@@ -16,5 +16,4 @@ api = Api(
     ordered=True,
 )
 
-api.config.SWAGGER_UI_DOC_EXPANSION = 'list'
 api.add_namespace(v2)

--- a/horde/apis/apiv2.py
+++ b/horde/apis/apiv2.py
@@ -16,4 +16,5 @@ api = Api(
     ordered=True,
 )
 
+api.config.SWAGGER_UI_DOC_EXPANSION = 'list'
 api.add_namespace(v2)

--- a/horde/flask.py
+++ b/horde/flask.py
@@ -10,6 +10,7 @@ from horde.redis_ctrl import ger_cache_url, is_redis_up
 
 cache = None
 HORDE = Flask(__name__)
+HORDE.config.SWAGGER_UI_DOC_EXPANSION = 'list'
 HORDE.wsgi_app = ProxyFix(HORDE.wsgi_app, x_for=1)
 
 SQLITE_MODE = os.getenv("USE_SQLITE", "0") == "1"

--- a/horde/flask.py
+++ b/horde/flask.py
@@ -10,7 +10,7 @@ from horde.redis_ctrl import ger_cache_url, is_redis_up
 
 cache = None
 HORDE = Flask(__name__)
-HORDE.config.SWAGGER_UI_DOC_EXPANSION = 'list'
+HORDE.config.SWAGGER_UI_DOC_EXPANSION = "list"
 HORDE.wsgi_app = ProxyFix(HORDE.wsgi_app, x_for=1)
 
 SQLITE_MODE = os.getenv("USE_SQLITE", "0") == "1"


### PR DESCRIPTION
what I really wanted was to enable deep linking support, but swagger-restx doesn't support it.
https://github.com/python-restx/flask-restx/issues/518
