### PR TITLE
fix: stats not updating; 'latest' compiled stats not used

### DIFF
--- a/horde/classes/kobold/genstats.py
+++ b/horde/classes/kobold/genstats.py
@@ -96,8 +96,10 @@ def get_compiled_textgen_stats_models() -> dict[str, dict[str, int]]:
         dict[str, dict[str, int]]: A dictionary with the model as the key and the requests as the values.
     """
 
+    latest_date = db.session.query(db.func.max(CompiledTextGenStatsModels.created)).scalar()
+
     models: tuple[CompiledTextGenStatsModels] = (
-        db.session.query(CompiledTextGenStatsModels).order_by(CompiledTextGenStatsModels.created.desc()).all()
+        db.session.query(CompiledTextGenStatsModels).filter(CompiledTextGenStatsModels.created == latest_date).all()
     )
 
     periods = ["day", "month", "total"]

--- a/horde/classes/stable/genstats.py
+++ b/horde/classes/stable/genstats.py
@@ -216,6 +216,8 @@ class CompiledImageGenStatsModels(db.Model):
 def get_compiled_imagegen_stats_models(model_state: str = "all") -> dict[str, dict[str, dict[str, int]]]:
     """Gets the precompiled image generation statistics for the day, month, and total periods for each model."""
 
+    latest_date = db.session.query(db.func.max(CompiledImageGenStatsModels.created)).scalar()
+
     models: tuple[CompiledImageGenStatsModels] = ()
 
     # If model_state is "all" we get all models, if it's "known" we get only known models, if it's "custom" we get only custom models
@@ -245,7 +247,7 @@ def get_compiled_imagegen_stats_models(model_state: str = "all") -> dict[str, di
         latest_entry = (
             db.session.query(CompiledImageGenStatsModels)
             .filter_by(model_name=model.model_name)
-            .order_by(CompiledImageGenStatsModels.created.desc())
+            .filter(CompiledImageGenStatsModels.created == latest_date)
             .first()
         )
 

--- a/sql_statements/cron/schedule_cron_job.sql
+++ b/sql_statements/cron/schedule_cron_job.sql
@@ -31,3 +31,5 @@ BEGIN
     RAISE NOTICE 'Cron job already exists with the same schedule for stored procedure: %. Skipping scheduling.', p_stored_procedure;
   END IF;
 END $$;
+
+UPDATE cron.job SET nodename = '';


### PR DESCRIPTION
- Running `UPDATE cron.job SET nodename = '';` allows pg_cron to operate as expected. Without it, there is connection problem when the scheduled job attempts to run.
- `created` is a now appropriately accounted for and only the latest compiled stats for the compiled 'models stats' are returned in the relevant queries.