### PR TITLE
tests: use postgres container w/ pg_cron; lint checking now happens in its own job

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     # runs-on: self-hosted
     env:
-      POSTGRES_URL: "localhost:5432/horde_test"
-      POSTGRES_PASS: "postgres"
+      POSTGRES_URL: "localhost:5432/postgres"
+      PGUSER: "postgres"
       PGPASSWORD: "postgres"
       REDIS_IP: "localhost"
       REDIS_SERVERS: '["localhost"]'
@@ -34,19 +34,6 @@ jobs:
       AI_HORDE_DEV_URL: "http://localhost:7001/api/" # For horde_sdk tests
 
     services:
-      postgres:
-        image: postgres:15.6-bullseye
-        env:
-          POSTGRES_PASSWORD: postgres
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
       redis:
         image: redis
         options: >-
@@ -57,8 +44,26 @@ jobs:
         ports:
           - 6379:6379
 
+      ai-horde-postgres:
+        image: ghcr.io/haidra-org/ai-horde-postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v3
+      - name: Create pg_cron extension
+        run: |
+          psql --host=localhost --dbname=postgres --username=postgres -c 'CREATE EXTENSION pg_cron;'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -72,12 +77,11 @@ jobs:
       - name: Install and run tests
         run: |
           python -m pip install -r requirements.txt
-          psql -h localhost -U postgres -c "CREATE DATABASE horde_test;"
           python server.py -vvvvi --horde stable &
           sleep 5
           curl -X POST --data-raw 'username=test_user' http://localhost:7001/register | grep -Po '<p style="background-color:darkorange;">\K.*(?=<\/p>)' > tests/apikey.txt
           export AI_HORDE_DEV_APIKEY=$(cat tests/apikey.txt)
-          pytest tests/ -s
+          
           python -m pip download --no-deps --no-binary :all: horde_sdk
           tar -xvf horde_sdk-*.tar.gz
           cd horde_sdk**/

--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -61,9 +61,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Create pg_cron extension
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          # cache: 'pip'
+      - run: python -m pip install --upgrade pip wheel setuptools
+      - name: Install and run tests
         run: |
-          psql --host=localhost --dbname=postgres --username=postgres -c 'CREATE EXTENSION pg_cron;'
+          python -m pip install -r requirements.txt -r requirements.dev.txt 
+          python server.py -vvvvi --horde stable &
+          sleep 5
+          curl -X POST --data-raw 'username=test_user' http://localhost:7001/register | grep -Po '<p style="background-color:darkorange;">\K.*(?=<\/p>)' > tests/apikey.txt
+          export AI_HORDE_DEV_APIKEY=$(cat tests/apikey.txt)
+          
+          python -m pip download --no-deps --no-binary :all: horde_sdk
+          tar -xvf horde_sdk-*.tar.gz
+          cd horde_sdk**/
+          pytest tests/ --ignore-glob=*api_calls.py --ignore-glob=*test_model_meta.py -s
+  
+  lint-check-job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -74,15 +93,3 @@ jobs:
           python -m pip install -r requirements.dev.txt 
           black --check .
           ruff .
-      - name: Install and run tests
-        run: |
-          python -m pip install -r requirements.txt
-          python server.py -vvvvi --horde stable &
-          sleep 5
-          curl -X POST --data-raw 'username=test_user' http://localhost:7001/register | grep -Po '<p style="background-color:darkorange;">\K.*(?=<\/p>)' > tests/apikey.txt
-          export AI_HORDE_DEV_APIKEY=$(cat tests/apikey.txt)
-          
-          python -m pip download --no-deps --no-binary :all: horde_sdk
-          tar -xvf horde_sdk-*.tar.gz
-          cd horde_sdk**/
-          pytest tests/ --ignore-glob=*api_calls.py --ignore-glob=*test_model_meta.py -s

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -38,8 +38,8 @@ jobs:
     # runs-on: self-hosted
     needs: required-label-job
     env:
-      POSTGRES_URL: "localhost:5432/horde_test"
-      POSTGRES_PASS: "postgres"
+      POSTGRES_URL: "localhost:5432/postgres"
+      PGUSER: "postgres"
       PGPASSWORD: "postgres"
       REDIS_IP: "localhost"
       REDIS_SERVERS: '["localhost"]'
@@ -55,19 +55,6 @@ jobs:
       AI_HORDE_DEV_URL: "http://localhost:7001/api/" # For horde_sdk tests
 
     services:
-      postgres:
-        image: postgres:15.6-bullseye
-        env:
-          POSTGRES_PASSWORD: postgres
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
       redis:
         image: redis
         options: >-
@@ -78,10 +65,28 @@ jobs:
         ports:
           - 6379:6379
 
+      ai-horde-postgres:
+        image: ghcr.io/haidra-org/ai-horde-postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
-      - uses: actions/checkout@v3      
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Create pg_cron extension
+        run: |
+          psql --host=localhost --dbname=postgres --username=postgres -c 'CREATE EXTENSION pg_cron;'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -95,7 +100,6 @@ jobs:
       - name: Install and run tests
         run: |
           python -m pip install -r requirements.txt
-          psql -h localhost -U postgres -c "CREATE DATABASE horde_test;"
           python server.py -vvvvi --horde stable &
           sleep 5
           curl -X POST --data-raw 'username=test_user' http://localhost:7001/register | grep -Po '<p style="background-color:darkorange;">\K.*(?=<\/p>)' > tests/apikey.txt

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -84,9 +84,31 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Create pg_cron extension
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          # cache: 'pip'
+      - run: python -m pip install --upgrade pip wheel setuptools
+      - name: Install and run tests
         run: |
-          psql --host=localhost --dbname=postgres --username=postgres -c 'CREATE EXTENSION pg_cron;'
+          python -m pip install -r requirements.txt -r requirements.dev.txt 
+          python server.py -vvvvi --horde stable &
+          sleep 5
+          curl -X POST --data-raw 'username=test_user' http://localhost:7001/register | grep -Po '<p style="background-color:darkorange;">\K.*(?=<\/p>)' > tests/apikey.txt
+          export AI_HORDE_DEV_APIKEY=$(cat tests/apikey.txt)
+          
+          python -m pip download --no-deps --no-binary :all: horde_sdk
+          tar -xvf horde_sdk-*.tar.gz
+          cd horde_sdk**/
+          pytest tests/ --ignore-glob=*api_calls.py --ignore-glob=*test_model_meta.py -s
+          
+  lint-check-job:
+    runs-on: ubuntu-latest
+    needs: required-label-job
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -97,15 +119,3 @@ jobs:
           python -m pip install -r requirements.dev.txt 
           black --check .
           ruff .
-      - name: Install and run tests
-        run: |
-          python -m pip install -r requirements.txt
-          python server.py -vvvvi --horde stable &
-          sleep 5
-          curl -X POST --data-raw 'username=test_user' http://localhost:7001/register | grep -Po '<p style="background-color:darkorange;">\K.*(?=<\/p>)' > tests/apikey.txt
-          export AI_HORDE_DEV_APIKEY=$(cat tests/apikey.txt)
-          
-          python -m pip download --no-deps --no-binary :all: horde_sdk
-          tar -xvf horde_sdk-*.tar.gz
-          cd horde_sdk**/
-          pytest tests/ --ignore-glob=*api_calls.py --ignore-glob=*test_model_meta.py -s

--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -2644,15 +2644,15 @@ class Heartbeat(Resource):
     def get(self):
         """If this loads, this node is available
         Includes some other metrics to gauge the health of this node"""
-        health = 'OK'
-        db_conn = True        
+        health = "OK"
+        db_conn = True
         try:
             db.session.execute(text("SELECT 1"))
         except Exception:
             db_conn = False
-            health = 'DOWN'
+            health = "DOWN"
         if waitress_metrics.queue > 0:
-            health = 'OVERLOADED'
+            health = "OVERLOADED"
         return {
             "message": health,
             "version": HORDE_VERSION,


### PR DESCRIPTION
- As found in the new [haidra-docker-images](https://github.com/Haidra-Org/haidra-docker-images) repo, the postgres service container is now a custom haidra-org authored one. 
  - Currently, the only difference from the official postgres image is the [installation](https://github.com/Haidra-Org/haidra-docker-images/blob/main/ai-horde/postgres/Dockerfile) and [configuration](https://github.com/Haidra-Org/haidra-docker-images/blob/main/ai-horde/postgres/init_pg_cron.sql) of [pg_cron](https://github.com/citusdata/pg_cron). However, by having this new repo, we can easily modify the database image in the future and it makes it available to developers for local purposes or even possible third-party horde deployers.
- The lint/format check now happens in a parallel job so the substance of the code can be checked without the lint causing a premature failure of the entire workflow.
- An incidental style fix, which was missed due to the tests recently not working as intended.