### PR TITLE
fix: new workers now check in more reliably; fix: more `skipped` keys to 0 instead of null

### DIFF
--- a/horde/classes/base/worker.py
+++ b/horde/classes/base/worker.py
@@ -259,7 +259,7 @@ class WorkerTemplate(db.Model):
     def check_in(self, **kwargs):
         # To avoid excessive commits,
         # we only record new changes on the worker every 30 seconds
-        if (datetime.utcnow() - self.last_check_in).total_seconds() < 30:
+        if (datetime.utcnow() - self.last_check_in).total_seconds() < 30 and (datetime.utcnow() - self.created).total_seconds() > 30:
             return
         self.ipaddr = kwargs.get("ipaddr", None)
         self.bridge_agent = sanitize_string(kwargs.get("bridge_agent", "unknown:0:unknown"))

--- a/horde/database/functions.py
+++ b/horde/database/functions.py
@@ -904,7 +904,7 @@ def get_sorted_wp_filtered_to_worker(worker, models_list=None, blacklist=None, p
 
 
 def count_skipped_image_wp(worker, models_list=None, blacklist=None, priority_user_ids=None):
-    ## Massively costly approach, doing 1 new query per count. Not sure about it.
+    ## FIXME: Massively costly approach, doing 1 new query per count. Not sure about it.
     ret_dict = {}
     open_wp_list = (
         db.session.query(ImageWaitingPrompt)
@@ -1078,6 +1078,22 @@ def count_skipped_image_wp(worker, models_list=None, blacklist=None, priority_us
     # 'worker_id': ,
     # 'blacklist': ,
     # 'kudos': skipped_kudos, # Not Implemented: See skipped_kudos TODO.
+    for key in [
+        "bridge_version",
+        "untrusted",
+        "performance",
+        "controlnet",
+        "post-processing",
+        "lora",
+        "nsfw",
+        "unsafe_ip",
+        "painting",
+        "img2img",
+        "worker_id",
+        "models",
+    ]:
+        if key not in ret_dict:
+            ret_dict[key] = 0
     return ret_dict
 
 


### PR DESCRIPTION
- The worker check-in fix would come up very rarely in production but was presenting a challenge for local development and for the CI runner. 
- It was incidentally noted that certain keys were unset (and unsent) from the skipped dict when they didn't apply and for consistency and completeness we're going to initialize them to 0 instead.