### PR TITLE
Refresh User cache when user is modified

### DIFF
--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -1334,7 +1334,7 @@ class UserSingle(Resource):
     @api.response(404, "Worker Not Found", models.response_model_error)
     def put(self, user_id=""):
         """Endpoint for horde admins to perform operations on users"""
-        user = user = database.find_user_by_id(user_id)
+        user = database.find_user_by_id(user_id)
         if not user:
             raise e.UserNotFound(user_id)
         self.args = self.parser.parse_args()
@@ -1469,6 +1469,7 @@ class UserSingle(Resource):
             ret_dict["admin_comment"] = user.admin_comment
         if not len(ret_dict):
             raise e.NoValidActions("No usermod operations selected!", rc="NoUserModSelected")
+        user.refresh_cache()
         return (ret_dict, 200)
 
 
@@ -2738,7 +2739,7 @@ class SharedKey(Resource):
     def put(self):
         """Create a new SharedKey for this user"""
         self.args = self.put_parser.parse_args()
-        user: User = database.find_user_by_api_key(self.args.apikey)
+        user = database.find_user_by_api_key(self.args.apikey)
         if not user:
             raise e.InvalidAPIKey("get sharedkey")
         if user.is_anon():
@@ -2760,6 +2761,7 @@ class SharedKey(Resource):
         )
         db.session.add(new_key)
         db.session.commit()
+        user.refresh_cache()
         return new_key.get_details(), 200
 
 
@@ -2929,6 +2931,7 @@ class SharedKeySingle(Resource):
             )
         db.session.delete(sharedkey)
         db.session.commit()
+        user.refresh_cache()
         return {"message": "OK"}, 200
 
 

--- a/horde/classes/base/user.py
+++ b/horde/classes/base/user.py
@@ -897,6 +897,19 @@ class User(db.Model):
             db.session.add(new_kd)
         db.session.commit()
 
+    def refresh_cache(self):
+        try:
+            privileges = [0, 1, 2]  # public, self-view, moderator
+            for privilege in privileges:
+                cache_name = f"cached_user_id_{self.id}_privilege_{privilege}"
+                hr.horde_r_delete(cache_name)
+
+            api_cache_name = f"cached_apikey_user_{self.api_key}"
+            hr.horde_r_delete(api_cache_name)
+
+        except Exception:
+            return None
+
     def record_problem_job(self, procgen, ipaddr, worker, prompt):
         # We do not report the admin as they do dev work often.
         if self.id == 1:

--- a/horde/database/functions.py
+++ b/horde/database/functions.py
@@ -155,13 +155,13 @@ def get_total_usage():
     return totals
 
 
-def find_user_by_oauth_id(oauth_id):
+def find_user_by_oauth_id(oauth_id) -> User | None:
     if oauth_id == "anon" and not ALLOW_ANONYMOUS:
         return None
     return db.session.query(User).filter_by(oauth_id=oauth_id).first()
 
 
-def find_user_by_username(username):
+def find_user_by_username(username) -> User | None:
     ulist = username.split("#")
     try:
         if int(ulist[-1]) == 0 and not ALLOW_ANONYMOUS:
@@ -173,21 +173,21 @@ def find_user_by_username(username):
     return user
 
 
-def find_user_by_id(user_id):
+def find_user_by_id(user_id) -> User | None:
     if int(user_id) == 0 and not ALLOW_ANONYMOUS:
         return None
     user = db.session.query(User).filter_by(id=user_id).first()
     return user
 
 
-def find_user_by_api_key(api_key):
+def find_user_by_api_key(api_key) -> User | None:
     if api_key == 0000000000 and not ALLOW_ANONYMOUS:
         return None
     user = db.session.query(User).filter_by(api_key=hash_api_key(api_key)).first()
     return user
 
 
-def find_user_by_sharedkey(shared_key):
+def find_user_by_sharedkey(shared_key) -> User | None:
     try:
         sharedkey_uuid = uuid.UUID(shared_key)
     except ValueError:

--- a/horde/horde_redis.py
+++ b/horde/horde_redis.py
@@ -119,3 +119,13 @@ def horde_r_get_json(key):
     if value is None:
         return None
     return json.loads(value)
+
+
+def horde_r_delete(key):
+    for hr in all_horde_redis:
+        try:
+            hr.delete(key)
+        except Exception as err:
+            logger.warning(f"Exception when deleting from redis servers {hr}: {err}")
+    if horde_local_r:
+        horde_local_r.delete(key)


### PR DESCRIPTION
Redis cache is now refreshed when User is modified.

## Problem:

After creating or deleting a shared key, it is not immediately reflected on `/get_user` endpoint as it serves now stale cached version.

This adds functionality to bust the user cache - both by id and by api_key - ensuring the cached results are always fresh.

## How to test:

1. call `GET /api/v2/find_user`, you should see `[]` under `sharedkey_ids`
2. call `GET /api/v2/users/:user_id`, you should see `[]` under `sharedkey_ids`
3. call `PUT /api/v2/sharedkeys` with body `{}`
4. call `GET /api/v2/find_user` again, you should see `['5d81849a...']` under `sharedkey_ids`
5. call `GET /api/v2/users/:user_id` again, you should also see `['5d81849a...']` under `sharedkey_ids`
6. call `DELETE /api/v2/sharedkeys/:keyId`
7. call `GET /api/v2/find_user`, you should see `[]` under `sharedkey_ids`
8. call `GET /api/v2/users/:user_id`, you should see `[]` under `sharedkey_ids`