### PR TITLE
Fix off-by-one in create shared keys

### DIFF
--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -2743,7 +2743,7 @@ class SharedKey(Resource):
             raise e.InvalidAPIKey("get sharedkey")
         if user.is_anon():
             raise e.AnonForbidden
-        if user.count_sharedkeys() > user.max_sharedkeys():
+        if user.count_sharedkeys() >= user.max_sharedkeys():
             raise e.Forbidden(f"You cannot have more than {user.max_sharedkeys()} shared keys.")
         expiry = None
         if self.args.expiry and self.args.expiry != -1:


### PR DESCRIPTION
Users with max_sharedkeys == 3 could create 4 shared keys.

This does not affect already created shared keys, just prohibits creations of new keys when user is at the limit.