### PR TITLE
Docker postgres pg_cron fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ apikey.txt
 .vscode/
 
 horde_sdk**
+/.env_docker

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.env_docker
+env_docker/
+env_docker.bak/
 
 # Spyder project settings
 .spyderproject
@@ -147,4 +150,3 @@ apikey.txt
 .vscode/
 
 horde_sdk**
-/.env_docker

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - redis
 
   postgres:
-    image: postgres:15.3-alpine
+    image: dex_postgres:latest
     container_name: postgres
     restart: always
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,9 @@ services:
       - redis
 
   postgres:
-    image: dex_postgres:latest
+    build:
+      context: docker/postgres
+      dockerfile: dockerfile
     container_name: postgres
     restart: always
     environment:

--- a/docker/postgres/dockerfile
+++ b/docker/postgres/dockerfile
@@ -1,0 +1,9 @@
+FROM postgres:15.4
+RUN apt-get update && apt-get install -y curl
+
+
+RUN apt-get -y install postgresql-15-cron
+RUN echo "shared_preload_libraries='pg_cron'" >> /usr/share/postgresql/postgresql.conf.sample
+RUN echo "cron.database_name='postgres'" >> /usr/share/postgresql/postgresql.conf.sample
+
+COPY init-db /docker-entrypoint-initdb.d

--- a/docker/postgres/dockerfile
+++ b/docker/postgres/dockerfile
@@ -1,8 +1,6 @@
-FROM postgres:15.4
-RUN apt-get update && apt-get install -y curl
+FROM postgres:15.3
+RUN apt-get update && apt-get install -y postgresql-15-cron
 
-
-RUN apt-get -y install postgresql-15-cron
 RUN echo "shared_preload_libraries='pg_cron'" >> /usr/share/postgresql/postgresql.conf.sample
 RUN echo "cron.database_name='postgres'" >> /usr/share/postgresql/postgresql.conf.sample
 

--- a/docker/postgres/init-db/002-pg-cron.sh
+++ b/docker/postgres/init-db/002-pg-cron.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# use same db as the one from env
+dbname="postgres"
+
+# create custom config
+customconf=/var/lib/postgresql/data/custom-conf.conf
+echo "" > $customconf
+echo "shared_preload_libraries = 'pg_cron'" >> $customconf
+echo "cron.database_name = '$dbname'" >> $customconf
+chown postgres $customconf
+chgrp postgres $customconf
+
+# include custom config from main config
+conf=/var/lib/postgresql/data/postgresql.conf
+found=$(grep "include = '$customconf'" $conf)
+if [ -z "$found" ]; then
+  echo "include = '$customconf'" >> $conf
+fi

--- a/docker/postgres/init-db/003-main.sql
+++ b/docker/postgres/init-db/003-main.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION pg_cron;


### PR DESCRIPTION
postgres image used in docker-compose now has the required `pg_cron` extension.

Closes #448 