### PR TITLE
Keep worker IP addresses and user contact info private when public_worker settings allow unprivileged requests to browse a user's workers

### DIFF
--- a/horde/classes/base/worker.py
+++ b/horde/classes/base/worker.py
@@ -472,6 +472,7 @@ class WorkerTemplate(db.Model):
             ret_dict["suspicious"] = len(self.suspicions)
         if details_privilege >= 1 or self.user.public_workers:
             ret_dict["owner"] = self.user.get_unique_alias()
+        if details_privilege >= 1:
             ret_dict["ipaddr"] = self.ipaddr
             ret_dict["contact"] = self.user.contact
         return ret_dict


### PR DESCRIPTION
the docs explicitly say that the IP address is privileged, and don't mention it being made available based on public_worker field.
If the user wants to make their contact info public, they can include it in the info field
  - there's an argument for a flag to make this available to other users as well (or even to make it available only to trusted workers), but I'm not picky here.


This issue was noticed by Sidorok [here](https://discord.com/channels/781145214752129095/1034314422912565288/1309661916989358100)


This fix is untested (I'm doing this from my tablet)
