### PR TITLE
fix: token suspicion adjustment

### DIFF
--- a/horde/classes/kobold/processing_generation.py
+++ b/horde/classes/kobold/processing_generation.py
@@ -124,7 +124,9 @@ class TextProcessingGeneration(ProcessingGeneration):
         # but new paradigms, backends and breakthroughs have made these numbers increasingly inaccurate or irrelevant.
 
         max_speed_per_multiplier = {
-            1: 100,
+            70: 30,
+            14: 100,
+            8: 150,
         }
 
         for params_count in max_speed_per_multiplier:

--- a/horde/classes/kobold/processing_generation.py
+++ b/horde/classes/kobold/processing_generation.py
@@ -111,13 +111,22 @@ class TextProcessingGeneration(ProcessingGeneration):
             return
         param_multiplier = model_reference.get_text_model_multiplier(self.model)
         unreasonable_speed = hv.suspicion_thresholds["text"]
+
+        # max_speed_per_multiplier = {
+        # 70: 12,
+        # 40: 22,
+        # 20: 35,
+        # 13: 50,
+        # 7: 70,
+        # }
+
+        # Once upon a time, before batching and other optimizations, these were the speeds we considered unreasonable
+        # but new paradigms, backends and breakthroughs have made these numbers increasingly inaccurate or irrelevant.
+
         max_speed_per_multiplier = {
-            70: 12,
-            40: 22,
-            20: 35,
-            13: 50,
-            7: 70,
+            1: 100,
         }
+
         for params_count in max_speed_per_multiplier:
             if param_multiplier >= params_count:
                 unreasonable_speed = max_speed_per_multiplier[params_count]


### PR DESCRIPTION
Once upon a time, before batching and other optimizations, these were the speeds we considered unreasonable but new paradigms, backends and breakthroughs have made these numbers increasingly inaccurate or irrelevant.

While I do think there has to be some sort of longer term solution (such as the one addressing the problem detailed in https://github.com/Haidra-Org/AI-Horde/issues/463), there have been virtually *only* false positives, and the few true positives boiled down to innocent misconfigurations.

Further, it appears that certain types of worker-reported failures can artificially inflate token count, which may be its own issue.

For the time being, I am advocating that the number is increased to 100t/s for most models, as recommended by henky, and that we respond to possible abuse of this relaxation with other, more complete and sound, measures.