### PR TITLE
fix: Unset worker team_id

### DIFF
--- a/horde/classes/base/worker.py
+++ b/horde/classes/base/worker.py
@@ -259,7 +259,7 @@ class WorkerTemplate(db.Model):
         return "OK"
 
     def set_team(self, new_team):
-        self.team_id = new_team.id
+        self.team_id = new_team.id if new_team else None
         db.session.commit()
         return "OK"
 


### PR DESCRIPTION
Fixes #480

From a brief scan, this is my best guess at the source of the HTTP 500 when sending a payload containing `"team": ""` in a `PUT /api/v2/workers/{worker id}`. `set_team()` is called with the value `None` in a couple places, where it looks to me to be expecting an object with an `id` variable - so `set_team()` tries to access the instance variable `.id` within the value `None`, which I believe would throw an error(?).

This change skips the dot accessor if the argument was `None` and just assigns `None` directly to the field instead.

Careful review requested! 🙏 I don't speak snek and I'm not familiar with SQLAlchemy. I also have yet to set up a development environment for AI Horde so I have not tested this change - but I'll get on the dev env over the weekend, if not before.