### PR TITLE
Fix: Horde Style Params Get Overwritten By User Provided Params

### DIFF
--- a/horde/apis/v2/kobold.py
+++ b/horde/apis/v2/kobold.py
@@ -202,7 +202,7 @@ class TextAsyncGenerate(GenerateTemplate):
         # Erroneous keys in the string
         self.prompt = self.existing_style.prompt.format_map(defaultdict(str, p=self.prompt))
         requested_n = self.params.get("n", 1)
-        self.params = self.existing_style.params
+        self.params = self.existing_style.params.copy()
         self.params["n"] = requested_n
         self.nsfw = self.existing_style.nsfw
         self.existing_style.use_count += 1

--- a/horde/apis/v2/kobold.py
+++ b/horde/apis/v2/kobold.py
@@ -202,7 +202,7 @@ class TextAsyncGenerate(GenerateTemplate):
         # Erroneous keys in the string
         self.prompt = self.existing_style.prompt.format_map(defaultdict(str, p=self.prompt))
         requested_n = self.params.get("n", 1)
-        self.params = self.existing_style.params.copy()
+        self.params = self.existing_style.params.deepcopy()
         self.params["n"] = requested_n
         self.nsfw = self.existing_style.nsfw
         self.existing_style.use_count += 1

--- a/horde/apis/v2/kobold.py
+++ b/horde/apis/v2/kobold.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import copy
 import random
 from collections import defaultdict
 
@@ -202,7 +203,7 @@ class TextAsyncGenerate(GenerateTemplate):
         # Erroneous keys in the string
         self.prompt = self.existing_style.prompt.format_map(defaultdict(str, p=self.prompt))
         requested_n = self.params.get("n", 1)
-        self.params = self.existing_style.params.deepcopy()
+        self.params = copy.deepcopy(self.existing_style.params)
         self.params["n"] = requested_n
         self.nsfw = self.existing_style.nsfw
         self.existing_style.use_count += 1

--- a/horde/apis/v2/stable.py
+++ b/horde/apis/v2/stable.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import copy
 import random
 from collections import defaultdict
 from datetime import datetime
@@ -393,7 +394,7 @@ class ImageAsyncGenerate(GenerateTemplate):
         # self.prompt = self.existing_style.prompt.format_map(defaultdict(str, p=self.prompt, np=self.negprompt))
         requested_n = self.params.get("n", 1)
         user_params = self.params
-        self.params = self.existing_style.params.deepcopy()
+        self.params = copy.deepcopy(self.existing_style.params)
         self.params["n"] = requested_n
         # This allows a style without specified width/height to receive these variables from the user.
         default_params = {"width", "height"}

--- a/horde/apis/v2/stable.py
+++ b/horde/apis/v2/stable.py
@@ -393,7 +393,7 @@ class ImageAsyncGenerate(GenerateTemplate):
         # self.prompt = self.existing_style.prompt.format_map(defaultdict(str, p=self.prompt, np=self.negprompt))
         requested_n = self.params.get("n", 1)
         user_params = self.params
-        self.params = self.existing_style.params
+        self.params = self.existing_style.params.copy()
         self.params["n"] = requested_n
         # This allows a style without specified width/height to receive these variables from the user.
         default_params = {"width", "height"}

--- a/horde/apis/v2/stable.py
+++ b/horde/apis/v2/stable.py
@@ -393,7 +393,7 @@ class ImageAsyncGenerate(GenerateTemplate):
         # self.prompt = self.existing_style.prompt.format_map(defaultdict(str, p=self.prompt, np=self.negprompt))
         requested_n = self.params.get("n", 1)
         user_params = self.params
-        self.params = self.existing_style.params.copy()
+        self.params = self.existing_style.params.deepcopy()
         self.params["n"] = requested_n
         # This allows a style without specified width/height to receive these variables from the user.
         default_params = {"width", "height"}


### PR DESCRIPTION
- because `self.params` is being set as a reference to `self.existing_style.params`, changes to `self.params` below (like width, height, n) end up being saved to the style when `self.existing_style.use_count` is updated and saved to the database. Copying the `self.existing_style.params` dictionary with `copy.deepcopy()` will ensure that `self.params` is a unique dictionary and is not in any way referencing the `self.existing_style` object's `params` dictionary and its contents.