### PR TITLE
Feat: Allows service accounts to send proxy information about their original IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Changelog
 
+# 4.48.0
+
+* Service accounts can now generate a proxy_passkey (using PUT on user). This key can be sent in the Proxy-Authorization header which will allow the AI Horde to accept their Proxy-For IP
+* Service accounts can now send a Proxy-for header containing the actual IP of the user they're proxying for. This will allow the AI Horde to provide rate limiting based on the origin user, rather than the proxy service's IP. For the AI Horde to accept the Proxy-For IP, the service account has to generate and send an Proxy-Authorization along with it.
+
 # 4.46.3
 
 * Can now specify `[SDXL]` or `[Flux]` on a custom model name, and it will be treated as having SDXL or flux baseline respectively.

--- a/horde/__init__.py
+++ b/horde/__init__.py
@@ -24,7 +24,8 @@ def after_request(response):
     response.headers["Access-Control-Allow-Origin"] = "*"
     response.headers["Access-Control-Allow-Methods"] = "POST, GET, OPTIONS, PUT, DELETE, PATCH"
     response.headers["Access-Control-Allow-Headers"] = (
-        "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, apikey, Client-Agent, X-Fields"
+        "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, apikey, "
+        "Client-Agent, X-Fields, X-Forwarded-For, Proxied-For, Proxy-Authorization"
     )
     response.headers["Horde-Node"] = f"{socket.gethostname()}:{args.port}:{HORDE_VERSION}"
     return response

--- a/horde/apis/limiter_api.py
+++ b/horde/apis/limiter_api.py
@@ -5,10 +5,9 @@
 from datetime import datetime, timedelta
 
 from flask import request
-from loguru import logger
 
+from horde.apis.request_utils import get_remoteaddr
 from horde.consts import WHITELISTED_SERVICE_IPS
-from horde.database import cached_passkeys
 from horde.utils import hash_api_key
 
 
@@ -27,19 +26,6 @@ class DynamicIPWhitelist:
 
 
 dynamic_ip_whitelist = DynamicIPWhitelist()
-
-
-def get_remoteaddr():
-    """Returns the remote address of the request, accounting for proxies"""
-    remoteaddr = request.remote_addr
-    passkey = request.headers.get("Proxy-Authorization", None)
-    if passkey:
-        if cached_passkeys.is_passkey_known(passkey):
-            remoteaddr = request.headers.get("Proxied-For", remoteaddr)
-        else:
-            logger.info(f"Unknown passkey {passkey} from {remoteaddr}. Ignoring Proxied-For header.")
-    logger.debug(f"Remote address: {remoteaddr}")
-    return remoteaddr
 
 
 # Used to for the flask limiter, to limit requests per url paths

--- a/horde/apis/limiter_api.py
+++ b/horde/apis/limiter_api.py
@@ -8,6 +8,7 @@ from flask import request
 from loguru import logger
 
 from horde.consts import WHITELISTED_SERVICE_IPS
+from horde.database import cached_passkeys
 from horde.utils import hash_api_key
 
 
@@ -31,8 +32,12 @@ dynamic_ip_whitelist = DynamicIPWhitelist()
 def get_remoteaddr():
     """Returns the remote address of the request, accounting for proxies"""
     remoteaddr = request.remote_addr
-    if request.headers.get("Proxy-Authorization", "") in ["ChangeMe"]:
-        remoteaddr = request.headers.get("Proxied-For", remoteaddr)
+    passkey = request.headers.get("Proxy-Authorization", None)
+    if passkey:
+        if cached_passkeys.is_passkey_known(passkey):
+            remoteaddr = request.headers.get("Proxied-For", remoteaddr)
+        else:
+            logger.info(f"Unknown passkey {passkey} from {remoteaddr}. Ignoring Proxied-For header.")
     logger.debug(f"Remote address: {remoteaddr}")
     return remoteaddr
 

--- a/horde/apis/models/v2.py
+++ b/horde/apis/models/v2.py
@@ -1318,6 +1318,10 @@ class Models:
                     example="User is sus",
                     description="(Privileged) Information about this users by the admins",
                 ),
+                "proxy_passkey": fields.String(
+                    example="0000000000000000",
+                    description="(Privileged) This service user's proxy passkey.",
+                ),
                 "account_age": fields.Integer(
                     example=60,
                     description="How many seconds since this account was created.",
@@ -1406,6 +1410,7 @@ class Models:
                     description="When set to true, the replacement filter will always be applied against this user",
                 ),
                 "reset_suspicion": fields.Boolean(description="Set the user's suspicion back to 0."),
+                "generate_proxy_passkey": fields.Boolean(description="(Re)Generate a service account proxy passkey."),
                 "contact": fields.String(
                     example="email@example.com",
                     description=(
@@ -1462,6 +1467,12 @@ class Models:
                     description="The new admin comment.",
                     min_length=5,
                     max_length=500,
+                ),
+                "proxy_passkey": fields.String(
+                    example="0000000000000000",
+                    description="The new service account proxy passkey.",
+                    min_length=16,
+                    max_length=16,
                 ),
             },
         )

--- a/horde/apis/models/v2.py
+++ b/horde/apis/models/v2.py
@@ -1410,7 +1410,10 @@ class Models:
                     description="When set to true, the replacement filter will always be applied against this user",
                 ),
                 "reset_suspicion": fields.Boolean(description="Set the user's suspicion back to 0."),
-                "generate_proxy_passkey": fields.Boolean(description="(Re)Generate a service account proxy passkey."),
+                "generate_proxy_passkey": fields.Boolean(
+                    description="(Re)Generate a service account proxy passkey.",
+                    default=False,
+                ),
                 "contact": fields.String(
                     example="email@example.com",
                     description=(

--- a/horde/apis/request_utils.py
+++ b/horde/apis/request_utils.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 Konstantinos Thoukydidis <mail@dbzer0.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from flask import request
+from loguru import logger
+
+from horde.database import cached_passkeys
+
+
+def get_remoteaddr():
+    """Returns the remote address of the request, accounting for proxies"""
+    remoteaddr = request.remote_addr
+    passkey = request.headers.get("Proxy-Authorization", None)
+    if passkey:
+        if cached_passkeys.is_passkey_known(passkey):
+            remoteaddr = request.headers.get("Proxied-For", remoteaddr)
+        else:
+            logger.info(f"Unknown passkey {passkey} from {remoteaddr}. Ignoring Proxied-For header.")
+    return remoteaddr

--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -19,6 +19,7 @@ import horde.apis.limiter_api as lim
 import horde.classes.base.stats as stats
 from horde import exceptions as e
 from horde.apis.models.v2 import Models, Parsers
+from horde.apis.request_utils import get_remoteaddr
 from horde.argparser import args
 from horde.classes.base import settings
 from horde.classes.base.detection import Filter
@@ -139,7 +140,7 @@ class GenerateTemplate(Resource):
         self.user = None
         self.apikey = None
         self.sharedkey = None
-        self.user_ip = request.remote_addr
+        self.user_ip = get_remoteaddr()
         # For now this is checked on validate()
         self.safe_ip = True
         self.validate()

--- a/horde/config.py
+++ b/horde/config.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Konstantinos Thoukydidis <mail@dbzer0.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from environs import Env
+
+env = Env()
+env.read_env()  # read .env file, if it exists
+
+
+class Config:
+    # WIP - Not enabled yet
+    horde_title: str = env.str("HORDE_TITLE", default="AI Horde")

--- a/horde/consts.py
+++ b/horde/consts.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-HORDE_VERSION = "4.47.0"
+HORDE_VERSION = "4.48.0"
 HORDE_API_VERSION = "2.5"
 
 WHITELISTED_SERVICE_IPS = {

--- a/horde/countermeasures.py
+++ b/horde/countermeasures.py
@@ -113,6 +113,24 @@ class CounterMeasures:
         return timeout
 
     @staticmethod
+    def report_proxy_suspicion(ipaddr):
+        """Increases the suspicion of proxy service's IP in redis temporarily"""
+        if not ip_s_r:
+            global test_timeout
+            test_timeout = test_timeout + test_timeout + 1
+            timeout = test_timeout * 3
+            logger.debug(f"Redis not available, so setting test_timeout to {test_timeout}")
+            CounterMeasures.set_timeout(ipaddr, timeout)
+            return test_timeout
+        current_suspicion = ip_s_r.get(ipaddr)
+        if current_suspicion is None:
+            current_suspicion = 0
+        current_suspicion = int(current_suspicion)
+        suspicion_timeout = 1
+        ip_s_r.setex(ipaddr, timedelta(hours=suspicion_timeout), current_suspicion + 1)
+        return current_suspicion
+
+    @staticmethod
     def retrieve_suspicion(ipaddr):
         """Checks the current suspicion of an IP address"""
         if not ip_s_r:

--- a/horde/database/__init__.py
+++ b/horde/database/__init__.py
@@ -4,7 +4,7 @@
 
 import horde.database.threads as threads
 from horde.argparser import args
-from horde.database.classes import Quorum
+from horde.database.classes import CachedPasskeys, Quorum
 from horde.logger import logger
 from horde.threads import PrimaryTimedFunction
 
@@ -25,6 +25,7 @@ priority_increaser = PrimaryTimedFunction(10, threads.increment_extra_priority, 
 compiled_filter_cacher = PrimaryTimedFunction(10, threads.store_compiled_filter_regex, quorum=quorum)
 regex_replacements_cacher = PrimaryTimedFunction(10, threads.store_compiled_filter_regex_replacements, quorum=quorum)
 known_image_models_cacher = PrimaryTimedFunction(300, threads.store_known_image_models, quorum=quorum)
+cached_passkeys = CachedPasskeys(5, threads.refresh_passkeys)
 
 if args.reload_all_caches:
     logger.info("store_prioritized_wp_queue()")

--- a/horde/database/classes.py
+++ b/horde/database/classes.py
@@ -26,3 +26,13 @@ class Quorum(PrimaryTimedFunction):
 
     def is_primary(self):
         return self.quorum == horde_instance_id
+
+
+class CachedPasskeys(PrimaryTimedFunction):
+    passkeys = []
+
+    def call_function(self):
+        self.passkeys = self.function(*self.args, **self.kwargs)
+
+    def is_passkey_known(self, passkey):
+        return passkey in self.passkeys

--- a/horde/database/classes.py
+++ b/horde/database/classes.py
@@ -5,8 +5,6 @@
 import uuid
 from datetime import datetime
 
-from loguru import logger
-
 from horde.threads import PrimaryTimedFunction
 from horde.vars import horde_instance_id
 
@@ -37,5 +35,4 @@ class CachedPasskeys(PrimaryTimedFunction):
         self.passkeys = self.function(*self.args, **self.kwargs)
 
     def is_passkey_known(self, passkey):
-        logger.debug(f"Checking if passkey {passkey} is known in {self.passkeys}")
         return passkey in self.passkeys

--- a/horde/database/classes.py
+++ b/horde/database/classes.py
@@ -5,6 +5,8 @@
 import uuid
 from datetime import datetime
 
+from loguru import logger
+
 from horde.threads import PrimaryTimedFunction
 from horde.vars import horde_instance_id
 
@@ -35,4 +37,5 @@ class CachedPasskeys(PrimaryTimedFunction):
         self.passkeys = self.function(*self.args, **self.kwargs)
 
     def is_passkey_known(self, passkey):
+        logger.debug(f"Checking if passkey {passkey} is known in {self.passkeys}")
         return passkey in self.passkeys

--- a/horde/database/functions.py
+++ b/horde/database/functions.py
@@ -1678,4 +1678,4 @@ def get_worker_messages(user_id=None, worker_id=None, validity="all", page=0):
 
 def get_all_users_passkeys():
     """Retrieves all users passkeys."""
-    return db.session.query(User.proxy_passkey).filter(User.proxy_passkey.isnot_(None)).all()
+    return db.session.query(User.proxy_passkey).filter(User.proxy_passkey.is_not_(None)).all()

--- a/horde/database/functions.py
+++ b/horde/database/functions.py
@@ -1678,4 +1678,4 @@ def get_worker_messages(user_id=None, worker_id=None, validity="all", page=0):
 
 def get_all_users_passkeys():
     """Retrieves all users passkeys."""
-    return db.session.query(User.proxy_passkey).filter(User.proxy_passkey.is_not(None)).all()
+    return [user.proxy_passkey for user in db.session.query(User.proxy_passkey).filter(User.proxy_passkey.is_not(None)).all()]

--- a/horde/database/functions.py
+++ b/horde/database/functions.py
@@ -1674,3 +1674,8 @@ def get_worker_messages(user_id=None, worker_id=None, validity="all", page=0):
     if validity == "expired":
         wmquery = wmquery.filter(WorkerMessage.expiry <= datetime.utcnow())
     return wmquery.offset(page).limit(50).all()
+
+
+def get_all_users_passkeys():
+    """Retrieves all users passkeys."""
+    return db.session.query(User.proxy_passkey).filter(User.proxy_passkey.isnot_(None)).all()

--- a/horde/database/functions.py
+++ b/horde/database/functions.py
@@ -1678,4 +1678,4 @@ def get_worker_messages(user_id=None, worker_id=None, validity="all", page=0):
 
 def get_all_users_passkeys():
     """Retrieves all users passkeys."""
-    return db.session.query(User.proxy_passkey).filter(User.proxy_passkey.is_not_(None)).all()
+    return db.session.query(User.proxy_passkey).filter(User.proxy_passkey.is_not(None)).all()

--- a/horde/database/threads.py
+++ b/horde/database/threads.py
@@ -473,7 +473,7 @@ def store_known_image_models():
             logger.debug("No known image models to store from the model reference")
 
 
-def refresh_passkeys(self):
+def refresh_passkeys():
     with HORDE.app_context():
         logger.debug(get_all_users_passkeys())
         return get_all_users_passkeys()

--- a/horde/database/threads.py
+++ b/horde/database/threads.py
@@ -475,5 +475,4 @@ def store_known_image_models():
 
 def refresh_passkeys():
     with HORDE.app_context():
-        logger.debug(get_all_users_passkeys())
         return get_all_users_passkeys()

--- a/horde/database/threads.py
+++ b/horde/database/threads.py
@@ -24,6 +24,7 @@ from horde.database.functions import (
     count_totals,
     find_user_by_contact,
     get_active_workers,
+    get_all_users_passkeys,
     get_available_models,
     prune_expired_stats,
     query_prioritized_wps,
@@ -470,3 +471,9 @@ def store_known_image_models():
 
         else:
             logger.debug("No known image models to store from the model reference")
+
+
+def refresh_passkeys(self):
+    with HORDE.app_context():
+        logger.debug(get_all_users_passkeys())
+        return get_all_users_passkeys()

--- a/horde/exceptions.py
+++ b/horde/exceptions.py
@@ -199,7 +199,7 @@ class MissingPrompt(wze.BadRequest):
 
 
 class CorruptPrompt(wze.BadRequest):
-    def __init__(self, username, ip, prompt, message=None, rc="CorruptPrompt"):
+    def __init__(self, username, ip, prompt, message=None, rc="CorruptPrompt", proxy_service_ip=None):
         if message:
             self.specific = message
         else:
@@ -208,6 +208,8 @@ class CorruptPrompt(wze.BadRequest):
                 "Please contact us if you think this is an error."
             )
         self.log = f"User '{username}' with IP '{ip}' sent an a corrupt prompt: '{prompt}'. Aborting!"
+        if proxy_service_ip:
+            self.log += f" Proxy IP: {proxy_service_ip}"
         self.rc = rc
 
 

--- a/horde/exceptions.py
+++ b/horde/exceptions.py
@@ -209,7 +209,7 @@ class CorruptPrompt(wze.BadRequest):
             )
         self.log = f"User '{username}' with IP '{ip}' sent an a corrupt prompt: '{prompt}'. Aborting!"
         if proxy_service_ip:
-            self.log += f" Proxy IP: {proxy_service_ip}"
+            self.log += f" Service Proxy IP: {proxy_service_ip}"
         self.rc = rc
 
 

--- a/horde/exceptions.py
+++ b/horde/exceptions.py
@@ -166,6 +166,7 @@ KNOWN_RC = [
     "UserNotDeleted",
     "DeletedUser",
     "CannotWipeActiveUser",
+    "NonServiceForbidden",
 ]
 
 

--- a/horde/routes.py
+++ b/horde/routes.py
@@ -4,7 +4,6 @@
 
 import os
 import random
-import secrets
 from uuid import uuid4
 
 import oauthlib
@@ -26,7 +25,7 @@ from horde.database import functions as database
 from horde.flask import HORDE, cache, db
 from horde.logger import logger
 from horde.patreon import patrons
-from horde.utils import ConvertAmount, hash_api_key, is_profane, sanitize_string
+from horde.utils import ConvertAmount, generate_api_key, hash_api_key, is_profane, sanitize_string
 from horde.vars import (
     google_verification_string,
     horde_contact_email,
@@ -245,7 +244,7 @@ def register():
                     page_title="Recaptcha Submit Error!",
                     use_recaptcha=False,
                 )
-        api_key = secrets.token_urlsafe(16)
+        api_key = generate_api_key()
         hashed_api_key = hash_api_key(api_key)
         if user:
             username = sanitize_string(request.form["username"])

--- a/horde/utils.py
+++ b/horde/utils.py
@@ -84,6 +84,11 @@ def sanitize_string(text):
     return bleach.clean(text).lstrip().rstrip()
 
 
+def generate_api_key():
+    """Generates a random API key."""
+    return secrets.token_urlsafe(16)
+
+
 def hash_api_key(unhashed_api_key):
     salt = os.getenv("secret_key", "s0m3s3cr3t")  # Note default here, just so it can run without env file #noqa SIM112
     return hashlib.sha256(salt.encode() + unhashed_api_key.encode()).hexdigest()

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ semver >= 3.0.2
 numpy ~= 1.26.4 # better_profanity fails on later versions of numpy
 markdownify
 stripe
+environs

--- a/sql_statements/4.48.0.txt
+++ b/sql_statements/4.48.0.txt
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN proxy_passkey VARCHAR(100);

--- a/sql_statements/4.48.0.txt.license
+++ b/sql_statements/4.48.0.txt.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Konstantinos Thoukydidis <mail@dbzer0.com>
+
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
* Service accounts can now generate a proxy_passkey (using PUT on user). This key can be sent in the Proxy-Authorization header which will allow the AI Horde to accept their Proxy-For IP
* Service accounts can now send a Proxy-for header containing the actual IP of the user they're proxying for. This will allow the AI Horde to provide rate limiting based on the origin user, rather than the proxy service's IP. For the AI Horde to accept the Proxy-For IP, the service account has to generate and send an Proxy-Authorization along with it.