### PR TITLE
fix: allow `outpainting` as a source_processing type

### DIFF
--- a/horde/classes/stable/waiting_prompt.py
+++ b/horde/classes/stable/waiting_prompt.py
@@ -50,7 +50,7 @@ class ImageWaitingPrompt(WaitingPrompt):
     width = db.Column(db.Integer, default=512, nullable=False, server_default=expression.literal(512))
     height = db.Column(db.Integer, default=512, nullable=False, server_default=expression.literal(512))
     source_image = db.Column(db.Text, default=None)
-    source_processing = db.Column(db.String(10), default="img2img", nullable=False, server_default="img2img")
+    source_processing = db.Column(db.String(12), default="img2img", nullable=False, server_default="img2img")
     source_mask = db.Column(db.Text, default=None)
     censor_nsfw = db.Column(
         db.Boolean,

--- a/horde/consts.py
+++ b/horde/consts.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-HORDE_VERSION = "5.0.2"
+HORDE_VERSION = "5.0.3"
 HORDE_API_VERSION = "2.5"
 
 WHITELISTED_SERVICE_IPS = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [project]
 name = "AI-Horde"
-version = "5.0.2"
+version = "5.0.3"
 description = "A Crowdsourced Generative AI cluster for everyone."
 authors = [
     {name = "db0", email = "mail@dbzer0.com"},

--- a/sql_statements/5.0.3.txt
+++ b/sql_statements/5.0.3.txt
@@ -1,0 +1,1 @@
+ALTER TABLE waiting_prompts ALTER COLUMN source_processing TYPE VARCHAR(12);

--- a/sql_statements/5.0.3.txt.license
+++ b/sql_statements/5.0.3.txt.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Tazlin <tazlin.on.github@gmail.com>
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-horde"
-version = "5.0.2"
+version = "5.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "alt-profanity-check" },


### PR DESCRIPTION
`outpainting` is allowed as a `source_processing` value, but prior to this change users who set this value will end up causing a 500 stemming from a `sqlalchemy.exc.DataError: (psycopg2.errors.StringDataRightTruncation) value too long for type character varying(10)` error.

This change allows the intended number of characters, plus an extra one for posterity, reinstating outpainting as a valid image processing mode. Hordelib has always supported this value - users would be able to start outpainting today as soon as the SQL script is run.