### PR TITLE
fix(stable): Ensure new random seed is generated for each job

### DIFF
--- a/horde/classes/stable/waiting_prompt.py
+++ b/horde/classes/stable/waiting_prompt.py
@@ -151,7 +151,7 @@ class ImageWaitingPrompt(WaitingPrompt):
         ret_payload = copy.deepcopy(self.gen_payload)
         # If self.seed is None, we randomize the seed we send to the worker each time.
         if self.seed is None:
-            ret_payload["seed"] = self.seed_to_int(self.seed)
+            ret_payload["seed"] = self.seed_to_int(None) # Always generate a new random seed if one wasn't provided
         elif self.seed_variation:
             ret_payload["seed"] = self.seed + (self.seed_variation * current_n)
             while ret_payload["seed"] >= 2**32:


### PR DESCRIPTION
This PR fixes a bug where duplicate images could be generated when using a random seed. The  function was reusing the initial random seed for subsequent images in a batch. This change ensures a new random seed is generated for every job if no specific seed was provided, resolving issue #188.