### PR TITLE
fix: don't make `stable_diffusion` the default model

### DIFF
--- a/horde/apis/models/stable_v2.py
+++ b/horde/apis/models/stable_v2.py
@@ -52,7 +52,7 @@ class ImageParsers(v2.Parsers):
             "models",
             type=list,
             required=False,
-            default=["stable_diffusion"],
+            default=[],
             help="The acceptable models with which to generate.",
             location="json",
         )


### PR DESCRIPTION
Currently, when a request omits `models`, it *defaults* to `stable_diffusion`. Instead, it should lead to a *random* model being chosen by the first available worker, which is what this PR changes.