### PR TITLE
chore: make waitress threads configurable via CLI

### DIFF
--- a/horde/argparser.py
+++ b/horde/argparser.py
@@ -92,6 +92,22 @@ arg_parser.add_argument(
     required=False,
     help="If true will prevent changing the reward date when forcing patreon rewards.",
 )
+arg_parser.add_argument(
+    "--waitress_threads",
+    action="store",
+    default=45,
+    required=False,
+    type=int,
+    help="Number of threads to use for waitress. Default is 45",
+)
+arg_parser.add_argument(
+    "--waitress_connection_limit",
+    action="store",
+    default=1024,
+    required=False,
+    type=int,
+    help="Number of maximum connections to use for waitress. Default is 1024",
+)
 arg_parser.add_argument("--test", action="store_true", help="Test")
 arg_parser.add_argument("--color", default=False, action="store_true", help="Enabled colorized logs")
 args = arg_parser.parse_args()

--- a/server.py
+++ b/server.py
@@ -45,13 +45,14 @@ if __name__ == "__main__":
         os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"  # Disable this on prod
         url_scheme = "http"
         logger.init_warn("WSGI Mode", status="Insecure")
+
     waitress.serve(
         HORDE,
         host=args.listen,
         port=args.port,
         url_scheme=url_scheme,
-        threads=45,
-        connection_limit=1024,
+        threads=args.waitress_threads,
+        connection_limit=args.waitress_connection_limit,
         asyncore_use_poll=True,
     )
     # HORDE.run(debug=True,host="0.0.0.0",port="5001")


### PR DESCRIPTION
Add CLI options to configure Waitress worker threads and connection limit.  This should be backwards compatible, having the same behavior as previous with current deployments. 

I have recently been testing the impact of various factors and threads/connection_limit have potentially significant effects. This should help tune deployments on a per-machine basis and potentially aide outside deployments.

- Introduces `--waitress_threads` (default 45, the previously hard coded value) and `--waitress_connection_limit` (default 1024, also the same prior)
- Replaces the hard-coded threads/connection_limit in server startup with values taken from args.