### PR TITLE
Fix random seed entropy source

### DIFF
--- a/horde/utils.py
+++ b/horde/utils.py
@@ -5,7 +5,6 @@
 import hashlib
 import json
 import os
-import random
 import secrets
 import uuid
 from datetime import datetime
@@ -20,8 +19,6 @@ from horde import exceptions as e
 from horde.flask import SQLITE_MODE
 
 profanity.load_censor_words()
-
-random.seed(random.SystemRandom().randint(0, 2**32 - 1))
 
 
 def is_profane(text):
@@ -120,8 +117,11 @@ def get_interrogation_form_expiry_date():
 
 
 def get_random_seed(start_point=0):
-    """Generated a random seed, using a random number unique per node"""
-    return random.randint(start_point, 2**32 - 1)
+    """Generate a random seed from OS randomness."""
+    max_seed = 2**32 - 1
+    if start_point > max_seed:
+        raise ValueError("start_point cannot be greater than the maximum seed")
+    return start_point + secrets.randbelow(max_seed - start_point + 1)
 
 
 def count_parentheses(s):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Guillem
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import pytest
+
+from horde.utils import get_random_seed
+
+
+def test_get_random_seed_uses_start_point_as_lower_bound(monkeypatch):
+    monkeypatch.setattr("horde.utils.secrets.randbelow", lambda upper_bound: upper_bound - 1)
+
+    assert get_random_seed(10) == 2**32 - 1
+
+
+def test_get_random_seed_allows_maximum_start_point(monkeypatch):
+    monkeypatch.setattr("horde.utils.secrets.randbelow", lambda upper_bound: 0)
+
+    assert get_random_seed(2**32 - 1) == 2**32 - 1
+
+
+def test_get_random_seed_rejects_start_point_above_seed_range():
+    with pytest.raises(ValueError):
+        get_random_seed(2**32)


### PR DESCRIPTION
## Summary

- replace module-level `random` seeding with per-call OS randomness via `secrets.randbelow()`
- avoid inherited PRNG state in forked/preloaded API processes producing matching seed sequences
- keep batching behavior unchanged
- add focused range tests for `get_random_seed()`

## Why

The previous version of this PR targeted batching, which was the wrong layer for the duplicate random-seed issue. The more plausible failure mode is the module-level `random` generator: if API workers inherit the same PRNG state from a forked/preloaded process, separate workers can emit the same seed sequence. Using `secrets.randbelow()` keeps every seed draw backed by OS randomness instead of a shared deterministic sequence.

Fixes #188.
Supersedes #513.

## Testing

- `python -m py_compile horde\utils.py tests\test_utils.py`
- `python -m ruff check horde\utils.py tests\test_utils.py`
- `git -c core.whitespace=cr-at-eol diff --check upstream/main -- horde\utils.py tests\test_utils.py`

`python -m pytest tests\test_utils.py -q` could not run in this checkout because app dependencies are not installed locally (`ModuleNotFoundError: No module named 'flask_dance'`).