### PR TITLE
fix(stable): avoid batching random seed jobs

### DIFF
--- a/horde/classes/stable/waiting_prompt.py
+++ b/horde/classes/stable/waiting_prompt.py
@@ -230,6 +230,14 @@ class ImageWaitingPrompt(WaitingPrompt):
         # logger.debug([payload,prompt_payload])
         return prompt_payload
 
+    def start_generation(self, worker, amount=1):
+        # A single worker payload can represent multiple images via n_iter, but
+        # it only carries one seed. Random seeds and seed_variation need one
+        # payload per procgen to avoid duplicate images within the same batch.
+        if self.seed is None or self.seed_variation:
+            amount = 1
+        return super().start_generation(worker, amount)
+
     def activate(self, downgrade_wp_priority=False, source_image=None, source_mask=None, extra_source_images=None, kudos_adjustment=0):
         # We separate the activation from __init__ as often we want to check if there's a valid worker for it
         # Before we add it to the queue


### PR DESCRIPTION
## Summary
- prevent stable image random-seed jobs from being bundled into a single worker payload with `n_iter > 1`
- also split `seed_variation` jobs so each procgen gets its own payload and seed calculation
- keep batching unchanged for explicit fixed-seed requests

Fixes #188

## Why this path
The existing pop flow calls `get_job_payload()` once per worker batch, then sets `payload["n_iter"] = len(procgen_list)`. When the prompt uses a random seed, that sends one seed for multiple generated images, which can produce duplicates within the same batch. This change forces one payload per procgen only when the seed must vary.

## Testing
- `python -m py_compile horde/classes/stable/waiting_prompt.py`
- `git diff --check`
