### PR TITLE
Prevent random-seed duplicate image batches

### DIFF
--- a/horde/classes/stable/waiting_prompt.py
+++ b/horde/classes/stable/waiting_prompt.py
@@ -115,6 +115,8 @@ class ImageWaitingPrompt(WaitingPrompt):
             # It then crashes in self.gen_payload["seed"] += self.seed_variation trying to None + Int
             if self.seed is None:
                 self.seed = self.seed_to_int(self.seed)
+        if self.needs_seed_safe_batching():
+            self.disable_batching = True
         # logger.debug(self.params)
         # logger.debug([self.prompt,self.params['width'],self.params['sampler_name']])
         self.things = self.width * self.height * self.get_accurate_steps()
@@ -169,6 +171,9 @@ class ImageWaitingPrompt(WaitingPrompt):
                 "comfy_pipeline": f"{pipline_name}.json",
             }
         return ret_payload
+
+    def needs_seed_safe_batching(self):
+        return self.n > 1 and (self.seed is None or self.seed_variation is not None)
 
     def get_share_metadata(self):
         """This is uploaded along with the image to the shared R2, when this WP shared"""


### PR DESCRIPTION
Fixes Haidra-Org/AI-Horde#188.

This takes the conservative server-side path discussed in the issue: when an image request asks for multiple generations and the server must preserve per-generation seed behavior, it disables batching for that waiting prompt.

Why:
- `start_generation()` currently creates one worker payload for the whole batch.
- `get_pop_payload()` then sets `n_iter` to the number of procgens in the batch.
- With a random seed, or with `seed_variation`, that means the worker receives one seed for multiple iterations, so duplicate images can be produced inside a single popped batch.

This keeps existing batching for fixed-seed multi-image requests because splitting those would still send the same fixed seed per job unless the requester provides `seed_variation`.

Validation run locally:
- `uvx ruff check horde/classes/stable/waiting_prompt.py`
- `python -m py_compile horde\classes\stable\waiting_prompt.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

I also attempted a focused pytest with repo requirements, but collection imports `horde`, whose package import parses server CLI args and exits when pytest's file path remains in argv. I left this as a production-only change to avoid adding a brittle test harness around that import side effect.