### PR TITLE
fix: add charset=utf-8 to Content-Type header for JSON responses

### DIFF
--- a/horde/flask.py
+++ b/horde/flask.py
@@ -47,6 +47,13 @@ def create_app():
 db = SQLAlchemy()
 HORDE = create_app()
 
+@HORDE.after_request
+def set_json_charset(response):
+    if response.content_type == "application/json":
+        response.content_type = "application/json; charset=utf-8"
+    return response
+
+
 if is_redis_up():
     try:
         cache_config = {


### PR DESCRIPTION
Fixes #494

## Problem
API responses return \Content-Type: application/json\ without charset, causing older clients (pre-2014) to treat the response as ASCII. This breaks Unicode/bilingual text display.

## Solution
Added a Flask after_request handler that sets \charset=utf-8\ on JSON responses.

## Changes
- \horde/flask.py\: Added \set_json_charset()\ after_request handler

## Testing
- All existing JSON endpoints will now include \charset=utf-8\ in their Content-Type header
- No behavior change for modern clients that default to UTF-8