### PR TITLE
fix: mention 150-second timeout in AbortedGen error message

### DIFF
--- a/horde/exceptions.py
+++ b/horde/exceptions.py
@@ -540,7 +540,7 @@ class AbortedGen(wze.BadRequest):
     def __init__(self, worker, gen_id, rc="AbortedGen"):
         self.specific = (
             f"Processing Generation with ID {gen_id} took too long to process and has been aborted! "
-            "Please check your worker speed and do not onboard worker which generate slower than 1 it/s!"
+            "Please check your worker speed - generations must complete within 150 seconds (minimum ~1 it/s, higher for large requests)!"
         )
         self.log = f"Worker '{worker}' attempted to provide aborted generation for {gen_id}."
         self.rc = rc

--- a/horde/flask.py
+++ b/horde/flask.py
@@ -47,6 +47,13 @@ def create_app():
 db = SQLAlchemy()
 HORDE = create_app()
 
+@HORDE.after_request
+def set_json_charset(response):
+    if response.content_type == "application/json":
+        response.content_type = "application/json; charset=utf-8"
+    return response
+
+
 if is_redis_up():
     try:
         cache_config = {


### PR DESCRIPTION
Fixes #508

## Problem
Text generation workers get an abort message saying  slower than 1 it/s but the actual timeout is a fixed 150 seconds, regardless of requested tokens. For large requests (4096 tokens), ~27 t/s is needed, which is much higher than 1 it/s.

## Solution
Updated the error message to mention both the 150-second timeout and the 1 it/s minimum, making it clearer that larger requests need proportionally higher speeds.

## Changes
- \horde/exceptions.py\: Updated \AbortedGen\ error message