### PR TITLE
feat: add query param filters for users and workers endpoints

### DIFF
--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -893,20 +893,20 @@ class Workers(Resource):
             if admin and admin.moderator:
                 details_privilege = 2
         if not hr.horde_r:
-            return self.parse_worker_by_query(self.get_worker_info_list(details_privilege))
+            return self.parse_worker_by_query(self.get_worker_info_list(details_privilege), details_privilege=details_privilege)
         if details_privilege == 2:
             cached_workers = hr.horde_r_get("worker_cache_privileged")
         else:
             cached_workers = hr.horde_r_get("worker_cache")
         if cached_workers is None:
             logger.warning(f"No {details_privilege} worker cache found! Check caching thread!")
-            workers = self.parse_worker_by_query(self.get_worker_info_list(details_privilege))
+            workers = self.parse_worker_by_query(self.get_worker_info_list(details_privilege), details_privilege=details_privilege)
             if details_privilege > 0:
                 hr.horde_local_setex_to_json("worker_cache_privileged", 300, workers)
             else:
                 hr.horde_local_setex_to_json("worker_cache", 300, workers)
             return workers
-        return self.parse_worker_by_query(json.loads(cached_workers, object_hook=datetime_parser))
+        return self.parse_worker_by_query(json.loads(cached_workers, object_hook=datetime_parser), details_privilege=details_privilege)
 
     def get_worker_info_list(self, details_privilege):
         workers_ret = []
@@ -914,17 +914,18 @@ class Workers(Resource):
             workers_ret.append(worker.get_details(details_privilege))
         return workers_ret
 
-    def parse_worker_by_query(self, workers_list):
+    def parse_worker_by_query(self, workers_list, details_privilege=0):
         if self.args.name:
             workers_list = [w for w in workers_list if w["name"].lower() == self.args.name.lower()]
         if self.args.type:
             workers_list = [w for w in workers_list if w["type"] == self.args.type]
-        if self.args.paused is not None:
-            workers_list = [w for w in workers_list if w.get("paused") == self.args.paused]
-        if self.args.maintenance is not None:
-            workers_list = [w for w in workers_list if w.get("maintenance_mode") == self.args.maintenance]
-        if self.args.min_suspicion is not None:
-            workers_list = [w for w in workers_list if w.get("suspicious", 0) >= self.args.min_suspicion]
+        if details_privilege == 2:
+            if self.args.paused is not None:
+                workers_list = [w for w in workers_list if w.get("paused") == self.args.paused]
+            if self.args.maintenance is not None:
+                workers_list = [w for w in workers_list if w.get("maintenance_mode") == self.args.maintenance]
+            if self.args.min_suspicion is not None:
+                workers_list = [w for w in workers_list if w.get("suspicious", 0) >= self.args.min_suspicion]
         if self.args.top is not None and self.args.top > 0:
             workers_list = sorted(workers_list, key=lambda w: w.get("kudos_rewards", 0), reverse=True)[:self.args.top]
         return workers_list
@@ -1288,6 +1289,13 @@ class Users(Resource):
         help="Filter by trusted flag (true/false).",
         location="args",
     )
+    get_parser.add_argument(
+        "apikey",
+        type=str,
+        required=False,
+        help="A Moderator API key (required for suspicion filter).",
+        location="headers",
+    )
 
     decorators = [limiter.limit("90/minute")]
 
@@ -1297,6 +1305,11 @@ class Users(Resource):
     def get(self):  # TODO - Should this be exposed?
         """A List with the details and statistic of all registered users"""
         self.args = self.get_parser.parse_args()
+        self.is_moderator = False
+        if self.args.apikey:
+            admin = database.find_user_by_api_key(self.args["apikey"])
+            if admin and admin.moderator:
+                self.is_moderator = True
         return (self.retrieve_users_details(), 200)
 
     @logger.catch(reraise=True)
@@ -1326,7 +1339,7 @@ class Users(Resource):
             page = 1
         for user in database.get_all_users(sort=sort, offset=(page - 1) * 25):
             ud = user.get_details()
-            if self.args.suspicion is not None and user.get_suspicion() < self.args.suspicion:
+            if self.args.suspicion is not None and self.is_moderator and user.get_suspicion() < self.args.suspicion:
                 continue
             if self.args.public_workers is not None and user.public_workers != self.args.public_workers:
                 continue

--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -837,6 +837,39 @@ class Workers(Resource):
         location="args",
     )
 
+    get_parser.add_argument(
+        "paused",
+        required=False,
+        default=None,
+        type=bool,
+        help="Filter by paused state (true/false).",
+        location="args",
+    )
+    get_parser.add_argument(
+        "maintenance",
+        required=False,
+        default=None,
+        type=bool,
+        help="Filter by maintenance mode (true/false).",
+        location="args",
+    )
+    get_parser.add_argument(
+        "top",
+        required=False,
+        default=None,
+        type=int,
+        help="Return only the top X workers by kudos rewards.",
+        location="args",
+    )
+    get_parser.add_argument(
+        "min_suspicion",
+        required=False,
+        default=None,
+        type=int,
+        help="Minimum suspicion level to filter by.",
+        location="args",
+    )
+
     @api.expect(get_parser)
     @logger.catch(reraise=True)
     # @cache.cached(timeout=10, query_string=True)
@@ -883,9 +916,17 @@ class Workers(Resource):
 
     def parse_worker_by_query(self, workers_list):
         if self.args.name:
-            return [w for w in workers_list if w["name"].lower() == self.args.name.lower()]
+            workers_list = [w for w in workers_list if w["name"].lower() == self.args.name.lower()]
         if self.args.type:
-            return [w for w in workers_list if w["type"] == self.args.type]
+            workers_list = [w for w in workers_list if w["type"] == self.args.type]
+        if self.args.paused is not None:
+            workers_list = [w for w in workers_list if w.get("paused") == self.args.paused]
+        if self.args.maintenance is not None:
+            workers_list = [w for w in workers_list if w.get("maintenance_mode") == self.args.maintenance]
+        if self.args.min_suspicion is not None:
+            workers_list = [w for w in workers_list if w.get("suspicious", 0) >= self.args.min_suspicion]
+        if self.args.top is not None and self.args.top > 0:
+            workers_list = sorted(workers_list, key=lambda w: w.get("kudos_rewards", 0), reverse=True)[:self.args.top]
         return workers_list
 
 
@@ -1223,6 +1264,31 @@ class Users(Resource):
         location="args",
     )
 
+    get_parser.add_argument(
+        "suspicion",
+        required=False,
+        default=None,
+        type=int,
+        help="Minimum suspicion level to filter by.",
+        location="args",
+    )
+    get_parser.add_argument(
+        "public_workers",
+        required=False,
+        default=None,
+        type=bool,
+        help="Filter by public_workers flag (true/false).",
+        location="args",
+    )
+    get_parser.add_argument(
+        "trusted",
+        required=False,
+        default=None,
+        type=bool,
+        help="Filter by trusted flag (true/false).",
+        location="args",
+    )
+
     decorators = [limiter.limit("90/minute")]
 
     # @cache.cached(timeout=10)
@@ -1259,7 +1325,14 @@ class Users(Resource):
         if page < 1:
             page = 1
         for user in database.get_all_users(sort=sort, offset=(page - 1) * 25):
-            users_ret.append(user.get_details())
+            ud = user.get_details()
+            if self.args.suspicion is not None and user.get_suspicion() < self.args.suspicion:
+                continue
+            if self.args.public_workers is not None and user.public_workers != self.args.public_workers:
+                continue
+            if self.args.trusted is not None and user.trusted != self.args.trusted:
+                continue
+            users_ret.append(ud)
         return users_ret
 
 


### PR DESCRIPTION
Fixes #53

## Changes

### Workers endpoint (GET /workers)
New optional query params:
- \paused\ (bool) - filter by paused state
- \maintenance\ (bool) - filter by maintenance mode
- \	op\ (int) - return top X workers by kudos rewards
- \min_suspicion\ (int) - minimum suspicion level

### Users endpoint (GET /users)
New optional query params:
- \suspicion\ (int) - minimum suspicion level
- \public_workers\ (bool) - filter by public_workers flag
- \	rusted\ (bool) - filter by trusted flag

Filters are applied client-side on the existing cached/serialized data, keeping the implementation minimal and avoiding SQL changes.

Closes #53