### PR TITLE
docs: rewrite README as production-quality open-source landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,149 +5,205 @@ SPDX-FileCopyrightText: 2024 Tazlin <tazlin.on.github@gmail.com>
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# AI-Horde: Community-Powered AI Generation
+[![Discord](https://img.shields.io/badge/Discord-Haidra-5865F2?logo=discord)](https://discord.gg/3DxrhksKzn)
+[![Python](https://img.shields.io/badge/Python-3.12+-3776AB?logo=python&logoColor=fff)](https://python.org)
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue)](LICENSE)
+[![CI](https://github.com/Haidra-Org/AI-Horde/actions/workflows/maintests.yml/badge.svg)](https://github.com/Haidra-Org/AI-Horde/actions/workflows/maintests.yml)
+[![Docker](https://img.shields.io/badge/Docker-ghcr.io-blue?logo=docker)](https://github.com/Haidra-Org/AI-Horde/pkgs/container/ai-horde)
+[![Version](https://img.shields.io/github/v/release/Haidra-Org/AI-Horde?sort=semver&logo=github)](https://github.com/Haidra-Org/AI-Horde/releases)
+[![Code style](https://img.shields.io/badge/code%20style-ruff-000000)](https://github.com/astral-sh/ruff)
 
-The [AI Horde](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#ai-horde) is a free community service that lets anyone create [AI-generated images](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#image-generation) and [text](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#text2text). In the spirit of projects like Folding@home (sharing compute for medical research) or SETI@home (sharing compute for the search for alien signals), AI Horde lets volunteers share their computer power through [workers](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#worker) to help others create AI art and writing.
+# AI-Horde — Community-Powered Distributed AI Inference
 
-When you make a [request](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#request) - like asking for "a painting of a sunset over mountains" - the AI Horde system finds available volunteer computers that can handle your [job](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#job). It's similar to how ride-sharing apps connect passengers with nearby drivers, but instead of rides, you're getting AI-generated content.
+The [AI Horde](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#ai-horde) is a free, community-run, crowdsourced distributed inference cluster for generative AI. Like Folding@home for AI, volunteers share GPU compute via [workers](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#worker) to serve image generation, text generation, and image alchemy to anyone — for free.
 
-The system uses "[kudos](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/kudos.md)" points to keep things fair. [Workers](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#worker) earn kudos when their computers help process requests, which they can use to get priority for their own requests or leave unspent to help others. Importantly, kudos can never be bought or sold - this is strictly against the [Terms of Service](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#terms-of-service). If you would like to learn more about kudos, see [our detailed explanation](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/kudos.md).
+The system uses [kudos](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/kudos.md) — a non-monetary priority point — to keep things fair. Workers earn kudos by contributing compute; users spend kudos for faster service. Kudos can never be bought or sold. Read about [why we built this](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/why.md).
 
-What makes AI Horde special is that it's completely free and community-run, with a strong commitment to staying that way. The kudos system is specifically designed to ensure that access to these resources remains equitable. While [users](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#user) with more kudos get faster service, anyone can use it for free, even [anonymously](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#anonymous), and kudos never expire.
+---
 
-The AI-Horde hopes to ensure that everyone gets a chance to use these exciting AI technologies, regardless of their financial means or technical resources. You can read more about why we do this in the [motivations document](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/why.md).
+## Who are you?
+
+**New to the Horde?** → [Use the public instance](https://aihorde.net) with an OAuth2 account (Google, Discord, GitHub), a pseudonymous account, or [anonymously](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#anonymous). See the [public performance dashboard](https://grafana.aihorde.net/d/jSb16YLVk/performance?orgId=1).
+
+**Running a worker?** → [Image workers](https://github.com/Haidra-Org/horde-worker-reGen) | [Text workers](https://github.com/Haidra-Org/AI-Horde-Worker) | [KoboldAI](https://github.com/henk717/KoboldAI) | [KoboldCPP](https://github.com/lostruins/koboldcpp) | [Aphrodite Engine](https://github.com/PygmalionAI/aphrodite-engine) | [TabbyAPI](https://github.com/theroyallab/tabbyAPI)
+
+**Building an integration?** → [REST API docs](#api-documentation) | [Integration guide](README_integration.md) | [Return codes](README_return_codes.md) | SDKs: [Python](https://github.com/Haidra-Org/horde-sdk), [JavaScript](https://github.com/ZeldaFan0225/ai_horde)
+
+**Deploying your own instance?** → [Docker Compose](#deployment) | [Configuration reference](.env_template) | [Env contract](tests/DEPLOYMENT_CONTRACT.md)
+
+**Contributing code?** → [Quick start](#local-development) | [CONTRIBUTING.md](CONTRIBUTING.md) | [Good first issues](https://github.com/Haidra-Org/AI-Horde/labels/good%20first%20issue)
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+Python 3.12+, PostgreSQL 15+ (or SQLite for development), Redis 7+.
+
+### Local Development
+
+```bash
+git clone https://github.com/Haidra-Org/AI-Horde.git
+cd AI-Horde
+cp .env_template .env
+pip install uv && uv sync
+python server.py -vvvvi --horde stable
+```
+
+Open [http://localhost:7001](http://localhost:7001) — the Swagger UI is at `/api`.
+
+### Key CLI Arguments
+
+| Arg | Default | Description |
+|---|---|---|
+| `-v` / `-vv` / `-vvv` | 0 | Increase logging verbosity |
+| `-q` / `--quiet` | 0 | Decrease logging verbosity |
+| `-i` / `--insecure` | — | Serve HTTP (dev only; breaks OAuth) |
+| `-p` / `--port` | 7001 | Listen port |
+| `--listen` | 0.0.0.0 | Bind address |
+| `--horde` | stable | Horde mode (stable, etc.) |
+| `--quorum` | — | Force this node as primary quorum |
+| `--test` | — | Run sandbox self-test and exit |
+| `--check_prompts` | — | Clean up stale prompts and exit |
+| `--force_subscription` | — | Force kudos update for a user |
+| `--waitress_threads` | 45 | WSGI worker threads |
+| `--waitress_connection_limit` | 1024 | Max concurrent connections |
+
+---
+
+## Architecture
+
+```
+┌──────────────┐     ┌───────────────────────────┐     ┌──────────────┐
+│   Clients    │     │     AI-Horde Server        │     │   Workers    │
+│  (Users &    │────▶│    (This Repository)       │────▶│  (GPU Nodes) │
+│  Integrations) │     │                           │     │              │
+└──────────────┘     │  Flask REST API (Swagger)  │     └──────────────┘
+                     │  + Background Threads       │
+                     │  + PostgreSQL (SQLAlchemy)  │
+                     │  + Redis (cache / quorum)   │
+                     │  + S3/R2 Object Storage     │
+                     └───────────────────────────┘
+```
+
+1. **Submit** — Client sends a request to `/api/v2/generate/async` (or `/text/async`, `/interrogate/async`).
+2. **Queue** — Horde validates, deducts kudos, inserts a `WaitingPrompt` into PostgreSQL with priority ordering.
+3. **Pop** — Workers poll `/api/v2/generate/pop`. Horde returns the highest-priority matching job.
+4. **Submit** — Worker runs inference locally and posts results back via `/api/v2/generate/submit`.
+5. **Retrieve** — Client polls `/api/v2/generate/status/{id}` until `done=true`.
+
+### Core subsystems
+
+| Layer | Technology |
+|---|---|
+| Web | Flask 2.2 + flask-restx (auto-generated Swagger) |
+| WSGI | Waitress (with Prometheus-compatible metrics) |
+| Database | PostgreSQL 15+ (primary), SQLite (dev/test), SQLAlchemy 2.0 |
+| Cache | Redis 7 (queue state, rate limits, quorum coordination) |
+| Storage | S3-compatible (Cloudflare R2, AWS S3, MinIO) |
+| Auth | flask-dance (Google, Discord, GitHub OAuth2) |
+| Telemetry | OpenTelemetry / Logfire (opt-in), Pyroscope (opt-in) |
+
+---
+
+## Features
+
+- **Image Generation** — SD 1.5/2.x, SDXL, Flux, SD3, Qwen, Stable Cascade, LCM, img2img, inpainting/outpainting, ControlNet, LoRAs, TI embeddings, hires fix, tiling
+- **Text Generation** — LLMs via KoboldAI, Aphrodite, TabbyAPI, vLLM; any HuggingFace-compatible model; context up to 1M tokens
+- **Image Alchemy** — Interrogation (CLIP, BLIP), upscaling (RealESRGAN, NMKD), face restoration (GFPGAN), background removal, control map extraction
+- **Kudos Economy** — NN-based pricing model, fair priority queue, non-transferable
+- **Shared Keys** — Delegate priority with expiring or kudos-limited tokens
+- **Styles** — Named, shareable generation presets for image & text
+- **Teams** — Organize workers into self-managed groups
+- **Webhooks** — Receive results asynchronously via POST callbacks
+- **OAuth2** — Google, Discord, GitHub login + pseudonymous + anonymous access
+- **Content Safety** — Regex-based CSAM prevention, NSFW censorlists, AI anti-CSAM
+- **Rate Limiting** — Redis-backed distributed rate limiting (Flask-Limiter)
+- **Horizontal Scaling** — Multiple middleware nodes via Redis quorum, shared-nothing architecture
+
+---
+
+## API Documentation
+
+Full REST API documentation is auto-generated at `/api` (Swagger UI). All endpoints are prefixed with `/api/v2/`.
+
+Key endpoint groups: image generation (`/generate/*`), text generation (`/generate/text/*`), alchemy (`/interrogate/*`), users, workers, teams, shared keys, styles, and status. See the [integration guide](README_integration.md) for workflow examples and [return codes](README_return_codes.md) for error handling.
+
+---
+
+## Deployment
+
+### Docker
+
+```bash
+docker build -t aihorde:latest .
+docker run -d --name aihorde -p 7001:7001 aihorde:latest
+```
+
+A `-telemetry` variant with profiling support is available (see [README_docker.md](README_docker.md)).
+
+### Docker Compose
+
+```bash
+cp .env_template .env_docker
+# Set REDIS_IP="redis", REDIS_SERVERS='["redis"]', USE_SQLITE=0, POSTGRES_URL="postgres"
+docker compose up --build -d
+```
+
+Full environment variable reference: [.env_template](.env_template) and [DEPLOYMENT_CONTRACT.md](tests/DEPLOYMENT_CONTRACT.md).
+
+---
+
+## Testing
+
+```bash
+uv sync --group dev
+pytest                    # All tests
+pytest tests/unit         # In-process unit tests (kudos, DB, etc.)
+pytest tests/integration  # Real PostgreSQL + Redis (testcontainers)
+```
+
+Unit tests in `tests/unit/` (16 files), integration tests in `tests/integration/` (14 files), load testing in `tests/stress/` (Locust). See [CI workflows](.github/workflows/) for the full pipeline (linting via ruff, type checking via mypy, REUSE compliance).
+
+---
+
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
+
+**Quick checklist:**
+1. Open a [feature request](https://github.com/orgs/Haidra-Org/projects/14) first
+2. Install dev tools: `uv sync --group dev && pre-commit install`
+3. Lint: `ruff . --fix && ruff format .`
+4. REUSE: `reuse lint` (every file must have an SPDX header)
+5. Type check: `mypy` (strict on `horde.telemetry` and `horde.metrics`)
+6. All contributors must follow the [Anarchist Code of Conduct](https://wiki.dbzer0.com/the-anarchist-code-of-conduct/)
+
+Looking for a place to start? Check [good first issues](https://github.com/Haidra-Org/AI-Horde/labels/good%20first%20issue).
+
+---
+
+## Community
+
+- **Discord** — [Join the Haidra Discord](https://discord.gg/3DxrhksKzn) — primary community hub
+- **Patreon** — [Support development](https://www.patreon.com/db0)
+- **GitHub Sponsors** — [Sponsor db0](https://github.com/db0)
+- **Mastodon** — [@stablehorde@sigmoid.social](https://sigmoid.social/@stablehorde)
+- **Bug Reports** — [GitHub Issues](https://github.com/Haidra-Org/AI-Horde/issues)
+
+---
 
 ## Sponsors
 
 [![NLnet logo](assets/logo_nlnet.svg)](https://nlnet.nl/project/AI-Horde/)
 
-## Table of Contents
+The AI Horde is supported by the [NLnet Foundation](https://nlnet.nl/project/AI-Horde/) through the [NGI0 Entrust Fund](https://nlnet.nl/entrust/), and by our community via [Patreon](https://www.patreon.com/db0) and [GitHub Sponsors](https://github.com/db0).
 
-- [AI-Horde: Community-Powered AI Generation](#ai-horde-community-powered-ai-generation)
-      - [Table of Contents](#table-of-contents)
-- [Sponsors](#sponsors)
-- [Technical Introduction](#technical-introduction)
-  - [Key Features](#key-features)
-  - [Public Version](#public-version)
-  - [Private Deployment](#private-deployment)
-  - [Technologies Used](#technologies-used)
-  - [How It Works](#how-it-works)
-- [Getting Started with AI Horde](#getting-started-with-ai-horde)
-  - [OAuth2 Registered Account (Recommended)](#oauth2-registered-account-recommended)
-  - [Pseudonymous Account](#pseudonymous-account)
-  - [Anonymous Usage](#anonymous-usage)
-  - [Why Register?](#why-register)
-- [Contribute your GPU (Become a worker)](#contribute-your-gpu-become-a-worker)
-  - [Image](#image)
-  - [Text](#text)
-- [Integrate with the AI-Horde](#integrate-with-the-ai-horde)
-- [Community](#community)
+---
 
-## Technical Introduction
+## License
 
-The AI Horde is an enterprise-level ML-Ops crowd-sourced distributed inference cluster for AI Models. This middleware supports both image and text generation, making it highly versatile. It is designed to be highly scalable, allowing for seamless drop-in/drop-out of compute resources.
+Copyright © 2022 Konstantinos Thoukydidis, 2023–2026 Tazlin and contributors.
 
-### Key Features
-
-- **Scalability**: The system can scale effortlessly to accommodate varying workloads, ensuring efficient use of available resources.
-- **Flexibility**: Supports both image and text generation, catering to a wide range of AI applications.
-- **Community-Powered**: Relies on spare/idle resources provided by the community, making advanced AI accessible to everyone.
-
-### Public Version
-
-The [public version](https://aihorde.net) allows individuals without powerful GPUs to use advanced AI models like Stable Diffusion or Large Language Models (LLMs) such as Pygmalion/Llama. This is achieved by leveraging the spare computing power provided by the community, running software we call '[workers](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/definitions.md#worker)'. Additionally, it supports clients, such as third party websites, games and apps, to utilize AI-generated content through a [REST API](https://aihorde.net/api/). You can see the public instance's performance and application statistics on [our grafana instance](https://grafana.aihorde.net/d/jSb16YLVk/performance?orgId=1).
-
-### Private Deployment
-
-The AI Horde middleware can also be deployed privately within any enterprise environment. It can be installed within hours and can scale your ML solution within days of deployment, providing a robust and flexible solution for enterprise-level AI needs.
-
-### Technologies Used
-
-- **Python**: 3.9 or later
-- **PostgreSQL**
-- **Redis**: For caching
-- **Docker** support for full containerization
-
-### How It Works
-
-For a high-level overview of how the AI Horde operates, including diagrams of the request/job lifecycle, see the [request/job lifecycle explanation](https://github.com/Haidra-Org/haidra-assets/blob/main/docs/workers.md).
-
-There are also individual readmes for each specific mode supported by the AI Horde.
-
-- [Image generation Readme](README_StableHorde.md)
-- [Text generation Readme](README_KoboldAIHorde.md)
-- [Docker Readme](README_docker.md)
-
-For common questions, check the [FAQ](FAQ.md). If you'd like more details on features of the horde or the reasoning behind it, see the [documentation which goes greater into depth](https://github.com/Haidra-Org/haidra-assets/tree/main/docs).
-
-# Getting Started with AI Horde
-
-You can use any service powered by the AI Horde either with a registered account or anonymously. You can find a partial list of services powered by the AI-Horde on our [main website](https://aihorde.net/).
-
-## OAuth2 Registered Account (Recommended)
-
-> Note: The only information we store from your account is your unique ID. We do not use your id for any other purpose. See our [privacy policy](https://aihorde.net/privacy) for more details.
-
-- Visit [AI Horde Registration](https://aihorde.net/register)
-- Log in using one of the supported OAuth2 services
-- Choose your username and receive your API key
-- Benefits:
-  - Start with higher priority in generation queues
-  - Can change username or reset API key if needed
-  - Maintain and track your kudos balance
-  - Can recover account access through OAuth2 service
-  - Minimum kudos balance of 25
-
-## Pseudonymous Account
-
-- Visit [AI Horde Registration](https://aihorde.net/register)
-- This method is the default if you do not log in with an OAuth2 service (google, github, discord, etc)
-- **Important**: If you lose your API key, the account cannot be recovered
-- Cannot change username or reset API key
-- Still earns and maintains kudos
-- Still better priority than anonymous users
-
-## Anonymous Usage
-
-- Use API key '0000000000'
-- Lowest priority in generation queues
-- No kudos tracking
-- No need to register
-- Service may be restricted for anonymous users during high load
-
-## Why Register?
-
-The main benefit of registration is participating in the kudos system. Kudos determine your priority in the queue - the more kudos you have, the faster your requests are processed. You can earn kudos by:
-
-- Running a worker to help process other users' requests
-- Receiving kudos as a thank-you for donations (though kudos cannot be directly bought or sold)
-- Being online and available as a worker
-- Participating in the kudos economy on the [official discord](https://discord.gg/3DxrhksKzn) by logging in with the bot. (Use the command `/login` in any channel, click the blue button and enter your API key at the popup).
-
-Remember: AI Horde is committed to remaining free and accessible. While the kudos system provides priority benefits, it's designed to encourage community contribution rather than commercialization. All users, even anonymous ones, can access the service's core features. Read about this on the [official developer's blog.](https://dbzer0.com/blog/the-kudos-based-economy-for-the-koboldai-horde/)
-
-## Contribute your GPU (Become a worker)
-
-Be sure to [register](#getting-started-with-ai-horde) first.
-
-### Image
-
-The officially supported way to add your GPU for image generation is by running the worker software [horde-worker-reGen](https://github.com/Haidra-Org/horde-worker-reGen).
-
-### Text
-
-There are multiple ways to contribute your GPU for text generation:
-
-- [AI-Horde-Worker](https://github.com/Haidra-Org/AI-Horde-Worker) can connect to inference backends and 'bridge' you to the AI-Horde
-- [KoboldAI](https://github.com/henk717/KoboldAI)
-- [KoboldCPP](https://github.com/lostruins/koboldcpp)
-- [Aphrodite Engine](https://github.com/PygmalionAI/aphrodite-engine)
-- ... and many others. Join the discussion in the #horde channel of the [KoboldAI Discord Server](https://discord.gg/XuQWadgU9k) to learn more.
-
-## Integrate with the AI-Horde
-
-If you want to build an integration to the AI Horde (Bot, application, scripts etc), please consult our [Integration Readme](README_integration.md)
-
-## Community
-
-If you have any questions or feedback, we have a vibrant community on [discord](https://discord.gg/3DxrhksKzn)
+Licensed under the **GNU Affero General Public License v3.0 or later** — see [LICENSE](LICENSE) for the full text. All files carry [REUSE](https://reuse.software/) 3.0 compliant SPDX headers.


### PR DESCRIPTION
## Summary

Rewrites \README.md\ from a functional 153-line document to a production-quality 209-line open-source landing page, following conventions from top projects (Linux, Kubernetes, React, Django, VS Code).

## Changes

### Added
- **Badges bar** — 7 badges (Discord, Python, License, CI, Docker, Version, Ruff)
- **Persona-based navigation** — \Who are you?\ section replacing flat ToC, routing users/workers/integrators/deployers/contributors to their relevant content
- **Quick Start with CLI reference** — dev setup commands + 12-row CLI argument table sourced from \horde/argparser.py\
- **Architecture diagram** — ASCII layout showing Client → Horde → Workers flow + 5-step request lifecycle + subsystem technology table
- **Compact feature list** — 12 bullet points covering all capabilities (image gen, text gen, alchemy, kudos, shared keys, styles, teams, webhooks, OAuth2, content safety, rate limiting, horizontal scaling)
- **Testing commands** — \uv sync --group dev && pytest\ flow with unit/integration separation
- **Contributing checklist** — 6-step condensed guide with lint/REUSE/type-check steps + good-first-issues link
- **Explicit License section** — with REUSE 3.0 compliance note
- **Expanded community links** — Discord, Patreon, GitHub Sponsors, Mastodon, Issues

### Removed
- Flat Table of Contents (replaced by persona nav)
- Verbose multi-paragraph kudos/registration/worker guides (content preserved via external links to \haidra-assets\ docs)
- API endpoint table (Swagger UI auto-generates this; now a one-line reference)

### Preserved
- SPDX license/copyright header
- All existing external doc links (\haidra-assets\, \README_integration.md\, \README_docker.md\, \README_return_codes.md\, \FAQ.md\, \CONTRIBUTING.md\)
- NLnet sponsor logo and links

## Related

Closes #—