### PR TITLE
fix: migrate Stripe subscriber cache to v15

### DIFF
--- a/horde/database/threads.py
+++ b/horde/database/threads.py
@@ -450,26 +450,22 @@ def store_stripe_members():
     subscriptions = stripe.Subscription.list()
     members = []
     for subscription in subscriptions:
-        product_id = subscription["items"]["data"][0]["price"]["product"]
+        subscription_data = subscription.to_dict()
+        product_id = subscription_data["items"]["data"][0]["price"]["product"]
         product = stripe.Product.retrieve(product_id)
-        subscription["product_name"] = product["name"]
-        subscription["metadata"] = subscription.get("metadata", {})
-        customer = stripe.Customer.retrieve(subscription["customer"])
-        subscription["customer_email"] = customer.get("email", "Unknown")
-        subscription["name"] = customer.get("name", "Unknown")
+        product_data = product.to_dict()
+        metadata = subscription_data.get("metadata", {})
+        customer = stripe.Customer.retrieve(subscription_data["customer"])
+        customer_data = customer.to_dict()
         members.append(
             {
-                "product_name": subscription["product_name"],
-                "email": subscription["customer_email"],
-                "name": subscription["name"],
-                "horde_id": (
-                    subscription["metadata"].get("horde_id")
-                    if subscription["metadata"].get("horde_id")
-                    else subscription["metadata"].get("horde")
-                ),
-                "alias": subscription["metadata"].get("alias"),
-                "sponsor_link": subscription["metadata"].get("sponsor_link"),
-                "status": subscription["status"],
+                "product_name": product_data["name"],
+                "email": customer_data.get("email", "Unknown"),
+                "name": customer_data.get("name", "Unknown"),
+                "horde_id": (metadata.get("horde_id") if metadata.get("horde_id") else metadata.get("horde")),
+                "alias": metadata.get("alias"),
+                "sponsor_link": metadata.get("sponsor_link"),
+                "status": subscription_data["status"],
             },
         )
     active_members = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     # The resolved version is pinned deterministically by uv.lock (currently 2.x).
     "numpy",
     "markdownify",
-    "stripe<15",
+    "stripe>=15,<16",
     "environs",
     "setuptools<82",
     # logfire is hard-pinned deliberately: the OTel/Logfire bridge API is not yet

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ emoji
 semver >= 3.0.2
 numpy
 markdownify
-stripe<15
+stripe>=15,<16
 environs
 setuptools<82
 logfire[flask,sqlalchemy,redis]==4.32.1

--- a/tests/unit/test_stripe_members.py
+++ b/tests/unit/test_stripe_members.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 Abhinav Gorrepati
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Regression coverage for Stripe subscription cache refreshes."""
+
+from __future__ import annotations
+
+import json
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any
+
+from horde.database import threads
+
+
+class StripeV15Resource:
+    """Minimal Stripe v15 resource: bracket access and ``to_dict()``, but no ``get()``."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._data.copy()
+
+
+def test_store_stripe_members_accepts_v15_resources(monkeypatch) -> None:
+    subscription = StripeV15Resource(
+        {
+            "items": {"data": [{"price": {"product": "prod_supporter"}}]},
+            "customer": "cus_supporter",
+            "metadata": {"horde_id": "Supporter#42", "alias": "Supporter", "sponsor_link": "https://example.com"},
+            "status": "active",
+        },
+    )
+    product = StripeV15Resource({"name": "Monthly Supporter"})
+    customer = StripeV15Resource({"email": "supporter@example.com", "name": "Supporter Name"})
+    fake_stripe = SimpleNamespace(
+        api_key=None,
+        Subscription=SimpleNamespace(list=lambda: [subscription]),
+        Product=SimpleNamespace(retrieve=lambda product_id: product),
+        Customer=SimpleNamespace(retrieve=lambda customer_id: customer),
+    )
+    cache: dict[str, str] = {}
+
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_123")
+    monkeypatch.setattr(threads, "stripe", fake_stripe)
+    monkeypatch.setattr(threads, "get_app", lambda: SimpleNamespace(app_context=nullcontext))
+    monkeypatch.setattr(threads.hr, "horde_r_set", lambda key, value: cache.__setitem__(key, value))
+
+    threads.store_stripe_members()
+
+    assert fake_stripe.api_key == "sk_test_123"
+    assert json.loads(cache["stripe_cache"]) == {
+        "42": {
+            "product_name": "Monthly Supporter",
+            "email": "supporter@example.com",
+            "name": "Supporter Name",
+            "horde_id": "Supporter#42",
+            "alias": "Supporter",
+            "sponsor_link": "https://example.com",
+            "status": "active",
+        },
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ requires-dist = [
     { name = "semver", specifier = ">=3.0.2" },
     { name = "setuptools", specifier = "<82" },
     { name = "sqlalchemy", specifier = "~=2.0.35" },
-    { name = "stripe", specifier = "<15" },
+    { name = "stripe", specifier = ">=15,<16" },
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
     { name = "unidecode" },
     { name = "waitress", specifier = "~=2.1.2" },
@@ -2528,15 +2528,15 @@ wheels = [
 
 [[package]]
 name = "stripe"
-version = "14.4.1"
+version = "15.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/01/59d92650146c6340e333c22b8a238561b022e8641ba255298dfe46b4137d/stripe-14.4.1.tar.gz", hash = "sha256:e3eecfb336819326cd2ab9a93f98eb01b49c4d4d93c9d167a52a68ab99c19a88", size = 1473321, upload-time = "2026-03-06T22:59:45.822Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/07/aed5656b3fd89a36e80835fe62c668692ee4ebf3a935095933d03f67a47b/stripe-15.3.0.tar.gz", hash = "sha256:ff05524255f51bf7df0e5bc4a99dbd0f737afd05587b7657c82e0d99c7fc45a4", size = 1514134, upload-time = "2026-06-24T22:49:40.276Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/0f/547eab75052384a72771b396a484556e5636629c031e5eafa8dc27af89ed/stripe-14.4.1-py3-none-any.whl", hash = "sha256:d6722b985dc3b4d6da01ff4fa95a975d3694a89bba96895bf17aa858073ff2b8", size = 2116642, upload-time = "2026-03-06T22:59:43.72Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f4/0dcf5bc464941132e3b109d26086a8a0aae7e4ed7e0243a1c47084b4de4b/stripe-15.3.0-py3-none-any.whl", hash = "sha256:99c427d306d9348123e73da3f4f2cae0a5732cac9b703155dba0418e32d3cf1c", size = 2172165, upload-time = "2026-06-24T22:49:38.18Z" },
 ]
 
 [[package]]
@@ -2634,13 +2634,13 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252", upload-time = "2026-03-23T15:16:58Z" },
@@ -2656,13 +2656,13 @@ resolution-markers = [
     "sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:2db3ae5404e32cb42b5fcbd94f13607761eaec0cf1687fde95095289d1e26cfb", upload-time = "2026-04-28T00:06:06Z" },


### PR DESCRIPTION
Updates the Stripe dependency to the v15 release line and makes the subscription cache compatible with Stripe's resource model.

Stripe v15 resources no longer implement dictionary methods such as `.get()`. The cache refresh now converts subscription, product, and customer resources with `to_dict()` before reading metadata and customer fields. The added regression uses resource-shaped mocks without `.get()` and verifies the cached supporter record remains unchanged.

Validation:

- `python -m pytest tests/unit -q`
- `ruff check horde/database/threads.py tests/unit/test_stripe_members.py`
- `uv lock --check`
- `reuse lint`

Fixes #525
