### PR TITLE
fix: generation attribution and request-validity reporting

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -185,6 +185,179 @@ jobs:
           fi
           docker compose -f tests/docker-compose.yml down
 
+  stress-shaped-job:
+    name: Locust staged-shape stress (no 5xx/crashes)
+    runs-on: ubuntu-latest
+    env:
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      HORDE_TEST_APIKEYS: '1'
+      AI_HORDE_TELEMETRY_ENABLED: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-test-python
+        with:
+          python-version: '3.13'
+      - uses: ./.github/actions/start-test-stack
+
+      - name: Start AI-Horde server
+        run: |
+          uv run python server.py -vvvvi --horde stable > server.log 2>&1 &
+          echo "$!" > server.pid
+
+          timeout=120
+          until curl -sf http://localhost:7001/api/v2/status/heartbeat > /dev/null 2>&1; do
+            timeout=$((timeout - 2))
+            if [[ "$timeout" -le 0 ]]; then
+              echo "Server failed to start within timeout"
+              cat server.log
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run staged-shape Locust run
+        # HordeStagesShape owns the user count, spawn rate, and total duration, so
+        # --users/--spawn-rate/--run-time are deliberately absent: Locust ignores
+        # them whenever a LoadTestShape is present. The 'smoke' profile ramps
+        # 2 -> 8 -> 2 users and stops itself at 120s.
+        run: |
+          uv run locust -f tests/stress/locustfile_shaped.py \
+            --host http://localhost:7001 \
+            --headless \
+            --stress-shape-profile smoke \
+            --bootstrap-requestors 4 \
+            --bootstrap-workers 8 \
+            --preflight-fail-hard \
+            --bootstrap-fail-hard \
+            --csv shaped \
+            --exit-code-on-error 0 \
+            --only-summary
+
+      - name: Gate on crash-class failures
+        run: uv run python tests/stress/check_smoke_results.py --stats shaped_stats.csv --failures shaped_failures.csv
+
+      - name: Scan server log for tracebacks
+        if: always()
+        run: |
+          if grep -n "Traceback (most recent call last)" server.log; then
+            echo "::warning::Server log contains a Python traceback during the staged-shape run; see the uploaded server.log artifact."
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stress-shaped-artifacts
+          path: |
+            server.log
+            shaped_stats.csv
+            shaped_failures.csv
+            shaped_stats_history.csv
+          if-no-files-found: ignore
+
+      - name: Stop server and local test stack
+        if: always()
+        run: |
+          if [[ -f server.pid ]]; then
+            kill "$(cat server.pid)" || true
+          fi
+          docker compose -f tests/docker-compose.yml down
+
+  stress-attribution-job:
+    name: Locust attribution oracle (no violations)
+    runs-on: ubuntu-latest
+    env:
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      HORDE_TEST_APIKEYS: '1'
+      AI_HORDE_TELEMETRY_ENABLED: '1'
+      # The oracle probes pop/declare and maintenance interleavings, not
+      # rate-limit behaviour. Leaving the limiter in force throttles the
+      # adversarial cadence the scenario depends on, which would let a run that
+      # never reached the interesting interleavings pass the zero-violation gate.
+      HORDE_TEST_RATELIMIT_DISABLED: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-test-python
+        with:
+          python-version: '3.13'
+      - uses: ./.github/actions/start-test-stack
+
+      - name: Start AI-Horde server
+        run: |
+          uv run python server.py -vvvvi --horde stable > server.log 2>&1 &
+          echo "$!" > server.pid
+
+          timeout=120
+          until curl -sf http://localhost:7001/api/v2/status/heartbeat > /dev/null 2>&1; do
+            timeout=$((timeout - 2))
+            if [[ "$timeout" -le 0 ]]; then
+              echo "Server failed to start within timeout"
+              cat server.log
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run attribution scenario
+        # Every user class sets fixed_count, so --users must equal their sum or
+        # Locust distributes the remainder by weight and distorts the shape:
+        # 6 pairs -> 12 flapping workers + 12 requesters, 2 maintenance workers
+        # -> 2 + 4 requesters. Each pair takes a disjoint 3-key slice of the
+        # worker pool for churn rotation, hence 20 bootstrapped worker owners.
+        run: |
+          uv run locust -f tests/stress/locustfile_attribution.py \
+            --host http://localhost:7001 \
+            --headless \
+            --users 30 \
+            --spawn-rate 10 \
+            --run-time 150s \
+            --attribution-pairs 6 \
+            --maintenance-workers 2 \
+            --attribution-evidence attribution_evidence.jsonl \
+            --bootstrap-requestors 8 \
+            --bootstrap-workers 20 \
+            --preflight-fail-hard \
+            --bootstrap-fail-hard \
+            --csv attribution \
+            --exit-code-on-error 0 \
+            --only-summary
+
+      - name: Gate on oracle violations
+        # --stats makes the checker reject a vacuous run that drove no requests,
+        # so "no violations" cannot pass by way of the workload never starting.
+        run: |
+          uv run python tests/stress/check_attribution_results.py \
+            --evidence attribution_evidence.jsonl \
+            --stats attribution_stats.csv
+
+      - name: Scan server log for tracebacks
+        if: always()
+        run: |
+          if grep -n "Traceback (most recent call last)" server.log; then
+            echo "::warning::Server log contains a Python traceback during the attribution run; see the uploaded server.log artifact."
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stress-attribution-artifacts
+          path: |
+            server.log
+            attribution_evidence.jsonl
+            attribution_stats.csv
+            attribution_failures.csv
+            attribution_stats_history.csv
+          if-no-files-found: ignore
+
+      - name: Stop server and local test stack
+        if: always()
+        run: |
+          if [[ -f server.pid ]]; then
+            kill "$(cat server.pid)" || true
+          fi
+          docker compose -f tests/docker-compose.yml down
+
   unit-test-job:
     name: Unit tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -210,6 +210,183 @@ jobs:
           fi
           docker compose -f tests/docker-compose.yml down
 
+  stress-shaped-job:
+    name: Locust staged-shape stress (no 5xx/crashes)
+    runs-on: ubuntu-latest
+    needs: required-label-job
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      HORDE_TEST_APIKEYS: '1'
+      AI_HORDE_TELEMETRY_ENABLED: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-test-python
+        with:
+          python-version: '3.13'
+      - uses: ./.github/actions/start-test-stack
+
+      - name: Start AI-Horde server
+        run: |
+          uv run python server.py -vvvvi --horde stable > server.log 2>&1 &
+          echo "$!" > server.pid
+
+          timeout=120
+          until curl -sf http://localhost:7001/api/v2/status/heartbeat > /dev/null 2>&1; do
+            timeout=$((timeout - 2))
+            if [[ "$timeout" -le 0 ]]; then
+              echo "Server failed to start within timeout"
+              cat server.log
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run staged-shape Locust run
+        # HordeStagesShape owns the user count, spawn rate, and total duration, so
+        # --users/--spawn-rate/--run-time are deliberately absent: Locust ignores
+        # them whenever a LoadTestShape is present. The 'smoke' profile ramps
+        # 2 -> 8 -> 2 users and stops itself at 120s.
+        run: |
+          uv run locust -f tests/stress/locustfile_shaped.py \
+            --host http://localhost:7001 \
+            --headless \
+            --stress-shape-profile smoke \
+            --bootstrap-requestors 4 \
+            --bootstrap-workers 8 \
+            --preflight-fail-hard \
+            --bootstrap-fail-hard \
+            --csv shaped \
+            --exit-code-on-error 0 \
+            --only-summary
+
+      - name: Gate on crash-class failures
+        run: uv run python tests/stress/check_smoke_results.py --stats shaped_stats.csv --failures shaped_failures.csv
+
+      - name: Scan server log for tracebacks
+        if: always()
+        run: |
+          if grep -n "Traceback (most recent call last)" server.log; then
+            echo "::warning::Server log contains a Python traceback during the staged-shape run; see the uploaded server.log artifact."
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stress-shaped-artifacts
+          path: |
+            server.log
+            shaped_stats.csv
+            shaped_failures.csv
+            shaped_stats_history.csv
+          if-no-files-found: ignore
+
+      - name: Stop server and local test stack
+        if: always()
+        run: |
+          if [[ -f server.pid ]]; then
+            kill "$(cat server.pid)" || true
+          fi
+          docker compose -f tests/docker-compose.yml down
+
+  stress-attribution-job:
+    name: Locust attribution oracle (no violations)
+    runs-on: ubuntu-latest
+    needs: required-label-job
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      HORDE_TEST_APIKEYS: '1'
+      AI_HORDE_TELEMETRY_ENABLED: '1'
+      # The oracle probes pop/declare and maintenance interleavings, not
+      # rate-limit behaviour. Leaving the limiter in force throttles the
+      # adversarial cadence the scenario depends on, which would let a run that
+      # never reached the interesting interleavings pass the zero-violation gate.
+      HORDE_TEST_RATELIMIT_DISABLED: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-test-python
+        with:
+          python-version: '3.13'
+      - uses: ./.github/actions/start-test-stack
+
+      - name: Start AI-Horde server
+        run: |
+          uv run python server.py -vvvvi --horde stable > server.log 2>&1 &
+          echo "$!" > server.pid
+
+          timeout=120
+          until curl -sf http://localhost:7001/api/v2/status/heartbeat > /dev/null 2>&1; do
+            timeout=$((timeout - 2))
+            if [[ "$timeout" -le 0 ]]; then
+              echo "Server failed to start within timeout"
+              cat server.log
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run attribution scenario
+        # Every user class sets fixed_count, so --users must equal their sum or
+        # Locust distributes the remainder by weight and distorts the shape:
+        # 6 pairs -> 12 flapping workers + 12 requesters, 2 maintenance workers
+        # -> 2 + 4 requesters. Each pair takes a disjoint 3-key slice of the
+        # worker pool for churn rotation, hence 20 bootstrapped worker owners.
+        run: |
+          uv run locust -f tests/stress/locustfile_attribution.py \
+            --host http://localhost:7001 \
+            --headless \
+            --users 30 \
+            --spawn-rate 10 \
+            --run-time 150s \
+            --attribution-pairs 6 \
+            --maintenance-workers 2 \
+            --attribution-evidence attribution_evidence.jsonl \
+            --bootstrap-requestors 8 \
+            --bootstrap-workers 20 \
+            --preflight-fail-hard \
+            --bootstrap-fail-hard \
+            --csv attribution \
+            --exit-code-on-error 0 \
+            --only-summary
+
+      - name: Gate on oracle violations
+        # --stats makes the checker reject a vacuous run that drove no requests,
+        # so "no violations" cannot pass by way of the workload never starting.
+        run: |
+          uv run python tests/stress/check_attribution_results.py \
+            --evidence attribution_evidence.jsonl \
+            --stats attribution_stats.csv
+
+      - name: Scan server log for tracebacks
+        if: always()
+        run: |
+          if grep -n "Traceback (most recent call last)" server.log; then
+            echo "::warning::Server log contains a Python traceback during the attribution run; see the uploaded server.log artifact."
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stress-attribution-artifacts
+          path: |
+            server.log
+            attribution_evidence.jsonl
+            attribution_stats.csv
+            attribution_failures.csv
+            attribution_stats_history.csv
+          if-no-files-found: ignore
+
+      - name: Stop server and local test stack
+        if: always()
+        run: |
+          if [[ -f server.pid ]]; then
+            kill "$(cat server.pid)" || true
+          fi
+          docker compose -f tests/docker-compose.yml down
+
   fork-pr-integration-note:
     runs-on: ubuntu-latest
     needs: required-label-job

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ horde_sdk**
 
 locust.conf
 .claude/*
+
+# Local design-scratch area for in-progress design notes; never committed.
+docs/design/

--- a/horde/apis/v2/base.py
+++ b/horde/apis/v2/base.py
@@ -664,7 +664,10 @@ class JobPopTemplate(Resource):
         if self.worker.paused and wp.user != self.worker.user:
             ret = wp.fake_generation(self.worker)
         else:
-            ret = wp.start_generation(self.worker, self.args.amount)
+            # ``self.models`` is the model list the pop SQL matched this WP
+            # against, so the recorded model is chosen from what the worker
+            # declared it would run rather than from later-read worker state.
+            ret = wp.start_generation(self.worker, self.args.amount, declared_models=self.models)
         return ret
 
     # We split this to its own function so that it can be extended with the specific vars needed to check in

--- a/horde/classes/base/processing_generation.py
+++ b/horde/classes/base/processing_generation.py
@@ -58,10 +58,14 @@ class ProcessingGeneration(db.Model):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # If there has been no explicit model requested by the user, we just choose the first available from the worker
         db.session.add(self)
         db.session.commit()
         if kwargs.get("model") is None:
+            # Callers on the pop path pass an explicit model selected against the
+            # worker's declared list. This branch serves the remaining callers
+            # (e.g. fake generations) that construct without one, deriving the
+            # model from the intersection of the worker's hosted models and the
+            # WP's requested models.
             worker_models = list(self.worker.get_model_names())
             # Under load, cache/session staleness can return an empty model list right
             # after check-in updates. Fall back to a direct DB read before giving up.
@@ -71,22 +75,16 @@ class ProcessingGeneration(db.Model):
                 worker_models = [
                     row.model for row in db.session.query(WorkerModel.model).filter(WorkerModel.worker_id == self.worker_id).all()
                 ]
-            # If we reached this point, it means there is at least 1 matching model between worker and client
-            # so we pick the first one.
             wp_models = list(self.wp.get_model_names())
-            matching_models = worker_models.copy()
             if len(wp_models) != 0:
                 matching_models = [model for model in wp_models if model in worker_models]
+            else:
+                matching_models = worker_models.copy()
             if len(matching_models) == 0:
+                # Record no model rather than a WP model the worker does not
+                # host: a mislabeled hosted model is worse than an empty one.
                 logger.warning(
-                    f"Unexpectedly No models matched between worker and request!: Worker Models: {worker_models}. "
-                    f"Request Models: {wp_models}. Will use random worker model.",
-                )
-                # If worker model metadata is missing, prefer the explicit request model over crashing.
-                matching_models = wp_models if len(wp_models) != 0 else worker_models
-            if len(matching_models) == 0:
-                logger.warning(
-                    f"No models available for generation {self.id}. "
+                    f"No models matched between worker and request for generation {self.id}. "
                     f"Worker Models: {worker_models}. Request Models: {wp_models}. Using empty model string.",
                 )
                 self.model = ""

--- a/horde/classes/base/waiting_prompt.py
+++ b/horde/classes/base/waiting_prompt.py
@@ -515,7 +515,18 @@ class WaitingPrompt(db.Model):
     ):
         active_worker_thread_count = active_worker_count[1]
         ret_dict = self.count_processing_gens()
-        ret_dict["waiting"] = max(self.n, 0)
+        # `self.n` holds the value read when this instance was loaded, which is
+        # earlier than the generation counts above: a generation started in
+        # between is counted here while `n` still includes the slot it consumed,
+        # reporting more outstanding generations than the request asked for. The
+        # slot count reconciles `waiting` against the counts actually reported.
+        # A faulted generation returns its slot to `n` and is reported separately
+        # as `restarted`, so it is not subtracted here. `jobs` is zero on rows
+        # predating the column, where no reconciliation is possible.
+        waiting = max(self.n, 0)
+        if self.jobs > 0:
+            waiting = min(waiting, max(self.jobs - ret_dict["processing"] - ret_dict["finished"], 0))
+        ret_dict["waiting"] = waiting
         # This might still happen due to a race condition on parallel requests. Not sure how to avoid it.
         if self.n < 0:
             logger.error("Request was popped more times than requested!")
@@ -552,7 +563,12 @@ class WaitingPrompt(db.Model):
         wait_time += highest_expected_time_left
         ret_dict["wait_time"] = round(wait_time)
         ret_dict["kudos"] = round(self.consumed_kudos)
-        ret_dict["is_possible"] = has_valid_workers
+        # The caller samples the validity verdict before these counts are taken, so
+        # it can predate an in-flight generation and contradict the processing count
+        # it is reported beside. An in-flight generation means a worker is serving
+        # this request, which is the same conclusion `wp_has_valid_workers` reaches
+        # from its own in-flight check.
+        ret_dict["is_possible"] = has_valid_workers or ret_dict["processing"] > 0
         return ret_dict
 
     def get_lite_status(self, **kwargs):

--- a/horde/classes/base/waiting_prompt.py
+++ b/horde/classes/base/waiting_prompt.py
@@ -313,16 +313,55 @@ class WaitingPrompt(db.Model):
     def needs_gen(self):
         return self.n > 0
 
-    def start_generation(self, worker, amount=1):
+    def start_generation(self, worker, amount: int = 1, declared_models: list[str] | None = None):
         with logfire.span(
             "horde.wp.start_generation",
             wp_id=str(self.id),
             worker_id=str(worker.id),
             amount=amount,
         ) as gen_span:
-            return self._start_generation(worker, amount, gen_span)
+            return self._start_generation(worker, amount, gen_span, declared_models)
 
-    def _start_generation(self, worker, amount=1, gen_span=None):
+    def _select_model(self, worker, declared_models: list[str] | None = None) -> str:
+        """Choose the single model recorded for every procgen in a batch.
+
+        ``declared_models`` is the model list the pop SQL matched this WP
+        against (the worker's declared list in the pop payload). It is the set
+        the worker committed to running, so the recorded model is drawn from it
+        rather than from later-read worker state. When absent (callers outside
+        the pop flow), the worker's currently hosted models stand in for it.
+        """
+        if declared_models is None:
+            declared_models = list(worker.get_model_names())
+            # A cache/session race right after check-in can momentarily return
+            # an empty hosted-model list, so fall back to a direct DB read.
+            if len(declared_models) == 0:
+                from horde.classes.base.worker import WorkerModel
+
+                declared_models = [
+                    row.model
+                    for row in db.session.query(WorkerModel.model).filter(WorkerModel.worker_id == worker.id).all()
+                ]
+        wp_models = list(self.get_model_names())
+        if len(wp_models) != 0:
+            candidates = [model for model in wp_models if model in declared_models]
+        else:
+            candidates = list(declared_models)
+        # The pop SQL matched this WP against ``declared_models``, so an empty
+        # overlap means the WP carried no constraint the match narrowed on; any
+        # declared model is one the worker will actually run.
+        if len(candidates) == 0:
+            candidates = list(declared_models)
+        if len(candidates) == 0:
+            logger.warning(
+                f"No models available to record for a generation on WP {self.id} by worker {worker.id}. "
+                f"WP Models: {wp_models}. Declared Models: {declared_models}.",
+            )
+            return ""
+        random.shuffle(candidates)
+        return candidates[0]
+
+    def _start_generation(self, worker, amount=1, gen_span=None, declared_models: list[str] | None = None):
         # # We have to do this to lock the row for updates, to ensure we don't have racing conditions on who is picking up requests
         # myself_refresh = db.session.query(
         #     type(self)
@@ -348,13 +387,13 @@ class WaitingPrompt(db.Model):
         self.refresh(worker)
         procgen_class = procgen_classes[self.wp_type]
         gens_list = []
-        model = None
+        # Select the batch's model once from the pop-declared list so every
+        # procgen records the same model the worker committed to running.
+        model = self._select_model(worker, declared_models)
         while safe_amount >= 1:
             safe_amount -= 1
             current_n -= 1
             new_gen = procgen_class(wp_id=self.id, worker_id=worker.id, model=model)
-            # For batched requests, we need all procgens to use the same model
-            model = new_gen.model
             logger.info(
                 f"Procgen with ID {new_gen.id} popped from WP {self.id} by worker {worker.id} "
                 f"('{worker.name}' / {worker.ipaddr}) - {current_n} gens left",

--- a/horde/classes/base/worker.py
+++ b/horde/classes/base/worker.py
@@ -599,8 +599,12 @@ class Worker(WorkerTemplate):
             db.session.add(blacklisted_word)
         db.session.flush()
 
-    def refresh_model_cache(self):
-        models_list = [m.model for m in self.models]
+    def refresh_model_cache(self) -> list[str]:
+        # Read the authoritative rows straight from worker_models rather than the
+        # self.models relationship collection. Under expire_on_commit=False that
+        # collection can remain loaded with pre-change rows across a commit, which
+        # would republish a stale list. A direct query always reflects what was written.
+        models_list = [row.model for row in db.session.query(WorkerModel.model).filter_by(worker_id=self.id).all()]
         try:
             hr.horde_r_setex(
                 f"worker_{self.id}_model_cache",

--- a/horde/classes/kobold/worker.py
+++ b/horde/classes/kobold/worker.py
@@ -60,8 +60,15 @@ class TextWorker(Worker):
         )
         db.session.commit()
 
-    def refresh_softprompt_cache(self):
-        softprompts_list = [s.softprompt for s in self.softprompts]
+    def refresh_softprompt_cache(self) -> list[str]:
+        # Read the authoritative rows straight from text_worker_softprompts rather than
+        # the self.softprompts relationship collection. Under expire_on_commit=False that
+        # collection can remain loaded with pre-change rows across a commit, which would
+        # republish a stale list. A direct query always reflects what was written.
+        softprompts_list = [
+            row.softprompt
+            for row in db.session.query(TextWorkerSoftprompts.softprompt).filter_by(worker_id=self.id).all()
+        ]
         try:
             hr.horde_r_setex(
                 f"worker_{self.id}_softprompts_cache",

--- a/horde/database/functions.py
+++ b/horde/database/functions.py
@@ -22,7 +22,7 @@ from horde.bridge_reference import (
 from horde.classes.base.detection import Filter
 from horde.classes.base.style import Style, StyleCollection, StyleModel, StyleTag
 from horde.classes.base.user import KudosTransferLog, User, UserRecords, UserSharedKey
-from horde.classes.base.waiting_prompt import WPAllowedWorkers, WPModels
+from horde.classes.base.waiting_prompt import WaitingPrompt, WPAllowedWorkers, WPModels
 from horde.classes.base.worker import WorkerMessage, WorkerModel, WorkerPerformance
 from horde.classes.kobold.processing_generation import TextProcessingGeneration
 from horde.classes.kobold.waiting_prompt import TextWaitingPrompt
@@ -1506,7 +1506,32 @@ def get_request_avg(request_type="image"):
     return float(perf_cache)
 
 
-def wp_has_valid_workers(wp):
+def wp_has_valid_workers(wp: WaitingPrompt) -> bool:
+    # An in-flight generation means a worker is actively serving this request, so it
+    # is possible regardless of the memoized verdict or the serving worker's current
+    # staleness. This live-state check runs before the cache so a pinned-false verdict
+    # cannot contradict a request that is presently being generated.
+    # Fake generations are decoys handed to paused/tricked workers and never yield a
+    # real result, so they are excluded here just as count_processing_gens excludes
+    # them from the processing bucket.
+    inflight_procgen_class = {
+        "image": ImageProcessingGeneration,
+        "text": TextProcessingGeneration,
+    }.get(wp.wp_type)
+    if inflight_procgen_class is not None:
+        has_inflight_generation = (
+            db.session.query(inflight_procgen_class.id)
+            .filter(
+                inflight_procgen_class.wp_id == wp.id,
+                inflight_procgen_class.generation.is_(None),
+                inflight_procgen_class.faulted.is_(False),
+                inflight_procgen_class.fake.is_(False),
+            )
+            .first()
+            is not None
+        )
+        if has_inflight_generation:
+            return True
     cached_validity = hr.horde_r_get(f"wp_validity_{wp.id}")
     if cached_validity is not None:
         return bool(int(cached_validity))

--- a/horde/limiter.py
+++ b/horde/limiter.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import os
+
+from flask import Flask
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
@@ -10,9 +13,28 @@ from horde.redis_ctrl import ger_limiter_url, is_redis_up
 
 limiter = Limiter(key_func=get_remote_address, default_limits=["90 per minute"], headers_enabled=True)
 
+# Follows the HORDE_TEST_APIKEYS test-gate precedent: these are the only string
+# values that flip an opt-in test toggle on. Anything else leaves production
+# behaviour untouched.
+_TEST_TOGGLE_TRUE_VALUES = {"1", "true", "yes", "on"}
 
-def init_limiter(app):
+
+def _is_ratelimit_disabled() -> bool:
+    # Exists so load-test scenarios (e.g. the queue-pressure rig) can drive the
+    # server hard without tripping flask-limiter's per-IP/per-key caps. Defaults
+    # to disabled-toggle-off, so unset env == current production behaviour.
+    return os.getenv("HORDE_TEST_RATELIMIT_DISABLED", "0").strip().lower() in _TEST_TOGGLE_TRUE_VALUES
+
+
+def init_limiter(app: Flask) -> None:
     logger.init("Limiter Cache", status="Connecting")
+    if _is_ratelimit_disabled():
+        # Setting the config before init_app makes flask-limiter honour it in
+        # both the redis and memory-only branches below (init_app reads
+        # RATELIMIT_ENABLED via setdefault), disabling default_limits and every
+        # per-route @limiter.limit decorator at once.
+        app.config["RATELIMIT_ENABLED"] = False
+        logger.init_warn("Limiter Cache", status="Disabled (HORDE_TEST_RATELIMIT_DISABLED)")
     if is_redis_up():
         try:
             app.config["RATELIMIT_STORAGE_URI"] = ger_limiter_url()

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -42,8 +42,8 @@ that re-export the User classes Locust should discover:
 
 ## Prerequisites
 
-- Install Locust into the project environment (`pip install locust`, or add it
-  to the dev extras your environment already uses).
+- Install Locust into the project environment (`uv sync --dev` or if not using
+  uv, `pip install locust`).
 - Bring up a running AI Horde deployment for Locust to target. The suite never
   starts the server or its backends itself; it only sends HTTP requests to the
   `--host` you give it.
@@ -228,3 +228,31 @@ own deployment with `--host`, `--port`, `--dbname`, `--user`, and `--password`.
 python tests/stress/pg_prober.py --port 15432 --duration 300 > pg_prober.jsonl
 ```
 
+## Continuous integration
+
+Three entrypoints run as parallel jobs on pull requests and on pushes to `main`
+(`.github/workflows/prtests.yml` and `maintests.yml`). Each job stands up the
+`tests/docker-compose.yml` stack, starts one server, bootstraps its keys through
+`/register`, and gates on a checker:
+
+| Job | Entrypoint | Gate |
+| --- | ---------- | ---- |
+| `stress-smoke-job` | `locustfile.py` | `check_smoke_results.py` |
+| `stress-shaped-job` | `locustfile_shaped.py` (`smoke` profile) | `check_smoke_results.py` |
+| `stress-attribution-job` | `locustfile_attribution.py` | `check_attribution_results.py` |
+
+The attribution job runs its server with `HORDE_TEST_RATELIMIT_DISABLED=1`: the
+oracle probes pop/declare and maintenance interleavings rather than rate-limit
+behaviour, and a throttled run could reach zero violations without ever reaching
+the interleavings the gate is meant to protect. It passes `--stats` to the
+checker for the same reason, so a run that drove no requests fails instead of
+reporting a vacuous pass. The two smoke jobs leave the limiter in force, since
+the suite counts 429s as successes and the gate is crash-class only.
+
+The hot-user convoy and queue-pressure scenarios are not in CI. Their verdicts
+come from `analyze_hot_user_convoy.py` and `analyze_queue_pressure.py`, which are
+descriptive rather than pass/fail, and both need a phase-aligned run directory
+(prober JSONL, `phases.json`, container logs) that a shared CI runner cannot
+produce meaningfully. Run them as described above. If they are added to CI later,
+run the analyzer as a non-gating step and keep the run directory as an uploaded
+artifact.

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -1,0 +1,230 @@
+# Stress testing
+
+The `tests/stress/` suite drives a running AI Horde deployment with
+production-shaped load and checks the results. It exists to reproduce the kinds
+of concurrency and attribution behaviour that only appear under realistic
+traffic: a mix of image, text, and interrogation users, a hot-user request
+convoy, a deliberately built queue backlog, and an attribution ground-truth
+oracle that watches for inconsistent API responses.
+
+The workload is a [Locust](https://locust.io/) suite. Locust is a black-box
+load generator: it exercises the HTTP API only and never provisions the
+server's own dependencies. The deployment under test and its Postgres, Redis,
+and object-storage backends are stood up separately (see Prerequisites).
+
+## Layout
+
+The workload lives in the `locustsuite` package so the user classes, shared
+helpers, and Locust event hooks stay in coherent modules:
+
+- `locustsuite/config.py` holds shared runtime constants and the parsed config
+  populated at test start.
+- `locustsuite/events.py` registers every custom CLI argument (each with a
+  matching `HORDE_*` environment variable), the optional API-key bootstrap, and
+  the target preflight check.
+- `locustsuite/users/` holds the User classes grouped by concern (image, text,
+  interrogation, meta browsing, misuse, and the attribution, hot-user-convoy,
+  and queue-pressure populations).
+- `locustsuite/shapes.py`, `helpers.py`, and `ground_truth.py` hold the staged
+  load profiles, shared request helpers, and the attribution oracle.
+
+The `locustfile*.py` files at the top of `tests/stress/` are thin entrypoints
+that re-export the User classes Locust should discover:
+
+- `locustfile.py` is the default entrypoint (the full user mix, classic
+  `-u`/`-r` operation).
+- `locustfile_shaped.py` adds a staged ramp/sustain/cooldown shape selected with
+  `--stress-shape-profile`.
+- `locustfile_attribution.py` spawns only the adversarial-timing text users that
+  the attribution oracle observes.
+- `locustfile_hot_user_convoy.py` spawns the hot-user convoy populations.
+- `locustfile_queue_pressure.py` spawns the queue-pressure populations.
+
+## Prerequisites
+
+- Install Locust into the project environment (`pip install locust`, or add it
+  to the dev extras your environment already uses).
+- Bring up a running AI Horde deployment for Locust to target. The suite never
+  starts the server or its backends itself; it only sends HTTP requests to the
+  `--host` you give it.
+- Stand up the server's backends. `tests/docker-compose.yml` provides an
+  optional long-lived Postgres, Redis, and Garage (S3) stack for local work:
+
+  ```
+  docker compose -f tests/docker-compose.yml up -d
+  ```
+
+  Host-published ports are configurable so the stack can coexist with other
+  local services. The relevant environment variables and their defaults are:
+
+  | Variable                       | Default |
+  | ------------------------------ | ------- |
+  | `AI_HORDE_TEST_POSTGRES_PORT`  | `5432`  |
+  | `AI_HORDE_TEST_REDIS_PORT`     | `6379`  |
+  | `AI_HORDE_TEST_GARAGE_S3_PORT` | `3900`  |
+  | `AI_HORDE_TEST_GARAGE_ADMIN_PORT` | `3903` |
+  | `AI_HORDE_TEST_GARAGE_RPC_PORT` | `3901` |
+
+- For load runs where the built-in rate limiter would otherwise dominate the
+  results, start the server with `HORDE_TEST_RATELIMIT_DISABLED=1`. The limiter
+  logs that it is disabled at init so the state is visible in the server output.
+  Leave it enabled when the point of the run is to observe rate-limit behaviour.
+
+## Running a scenario
+
+Custom AI Horde options are read from CLI arguments or `HORDE_*` environment
+variables. Locust's own options may additionally be set in a `locust.conf`
+file. Copy the example and edit it for your environment:
+
+```
+cp tests/stress/locust.conf.example tests/stress/locust.conf
+```
+
+`locust.conf` is git-ignored and holds Locust's built-in options only; the
+custom AI Horde options are documented inline in `locust.conf.example` with
+their environment-variable names.
+
+Default mixed workload:
+
+```
+cd tests/stress && locust
+# or, from the repo root:
+locust -f tests/stress/locustfile.py --host http://localhost:7001
+```
+
+Staged load profile:
+
+```
+locust -f tests/stress/locustfile_shaped.py --stress-shape-profile smoke
+```
+
+The scenario entrypoints take fixed per-class user counts so a run reproduces
+the same shape every time. The usage block at the top of each
+`locustfile_*.py` lists the exact flags. In outline:
+
+```
+# Attribution oracle
+locust -f tests/stress/locustfile_attribution.py --host http://localhost:7001 \
+    --headless --users 40 --spawn-rate 20 --run-time 150s \
+    --attribution-pairs 6 --maintenance-workers 2 \
+    --attribution-evidence attribution_evidence.jsonl --csv attribution
+
+# Hot-user lock convoy
+locust -f tests/stress/locustfile_hot_user_convoy.py --host http://localhost:7001 \
+    --headless --users 120 --spawn-rate 60 --run-time 300s \
+    --hc-anon-requestors 60 --hc-heavy-requestors 6 --hc-workers 40 \
+    --hc-status-pollers 12 --hc-kudos-users 2 \
+    --hc-baseline 60 --hc-pressure 180 --hc-relief 60 --hc-n-pressure 6 \
+    --csv hc --csv-full-history
+
+# Queue pressure
+locust -f tests/stress/locustfile_queue_pressure.py --host http://localhost:7001 \
+    --headless --users 60 --spawn-rate 30 --run-time 300s \
+    --qp-workers 20 --qp-served-requestors 8 --qp-backlog-requestors 24 \
+    --qp-backlog-target 3000 --qp-baseline 60 --qp-pressure 180 --qp-relief 60 \
+    --csv qp --csv-full-history
+```
+
+### Test users and API keys
+
+Meaningful runs need requestor and worker API keys. There are three ways to
+supply them:
+
+- Pass them directly via `--requestor-api-keys` / `--worker-api-keys` (or the
+  `HORDE_REQUESTOR_API_KEYS` / `HORDE_WORKER_API_KEYS` environment variables).
+- Let the suite auto-register keys at test start via `--bootstrap-requestors` /
+  `--bootstrap-workers`. This posts the public `/register` form and works only
+  against a local deployment where reCAPTCHA is disabled. Untrusted users are
+  capped at three distinct workers each, so keep `--bootstrap-workers` at least
+  `ceil(worker_users / 3)`.
+- Mint keys on disk ahead of time with `gen_api_keys.py`. It registers users
+  through the test bootstrap endpoint `/api/v2/dev/test-user`, which requires
+  the server to run with `HORDE_TEST_APIKEYS=1` and local loopback access. The
+  keys print one per line and can be pasted straight into the comma-separated
+  `HORDE_REQUESTOR_API_KEYS` / `HORDE_WORKER_API_KEYS` values:
+
+  ```
+  python tests/stress/gen_api_keys.py -n 20 --host http://localhost:7001
+  python tests/stress/gen_api_keys.py -n 5 --role worker --out worker_keys.txt
+  ```
+
+  The auto-bootstrap path covers most runs, so `gen_api_keys.py` is only needed
+  when other tooling wants the raw keys on disk.
+
+Before spawning users, each entrypoint runs a target preflight
+(`GET /api/v2/status/heartbeat`) so a misconfigured `--host` fails early rather
+than as a wall of connection errors. Control it with `--skip-preflight`,
+`--preflight-fail-hard`, and `--preflight-timeout`.
+
+## Interpreting results
+
+The suite treats operational responses (HTTP 429 rate limits, worker-contention
+result codes, deliberate misuse 4xx) as successes so they do not pollute the
+Locust failure table. The checker and analyzer scripts turn the raw run
+artifacts into a verdict.
+
+- `check_smoke_results.py` gates a smoke run on stability rather than
+  performance. It reads the Locust `<prefix>_stats.csv` (and the matching
+  `_failures.csv`) and fails only on crash signals: a 5xx, or a transport-level
+  exception with no HTTP status. Unclassified benign 4xx are reported as
+  warnings. A run that drove no requests at all also fails.
+
+  ```
+  python tests/stress/check_smoke_results.py --stats smoke_stats.csv
+  ```
+
+- `check_attribution_results.py` gates an attribution run on oracle evidence.
+  The attribution scenario writes one JSONL record per consistency violation.
+  The checker treats that evidence file as the authority. Its default mode
+  passes only when zero violations were observed (the assertion that a fixed
+  server never produces the inconsistent responses the scenario probes for).
+  With `--expect-violations` it inverts the gate and passes only when at least
+  one violation was elicited, so a run against a server known to contain the
+  defect proves the scenario still exercises it. Supplying `--stats` additionally
+  fails a run that drove zero requests.
+
+  ```
+  python tests/stress/check_attribution_results.py --evidence attribution_evidence.jsonl --stats attribution_stats.csv
+  python tests/stress/check_attribution_results.py --evidence prefix_evidence.jsonl --expect-violations
+  ```
+
+- `analyze_hot_user_convoy.py` and `analyze_queue_pressure.py` correlate a
+  run's artifacts into a phase-aligned verdict. Each reads a run directory
+  containing the Locust CSV history, the Postgres prober JSONL, and a
+  `phases.json` marking the baseline, pressure, and relief boundaries (the hot
+  convoy analyzer also reads before/after `pg_stat_statements` snapshots; the
+  queue-pressure analyzer also reads the Postgres container log). Each buckets
+  every series into the three phases and prints a timeline plus a conclusion
+  block. The verdict is descriptive: it states, for each element of the
+  lock-convoy signature (tuple-lock queue depth on the hot rows,
+  idle-in-transaction blocking chains, latency degradation of writes versus
+  reads, deadlocks confined to the pressure window, and recovery in the relief
+  phase), whether the run reproduced it. A partial reproduction is reported as
+  exactly that per element rather than being rounded up to a confirmation.
+
+  ```
+  python tests/stress/analyze_hot_user_convoy.py --run-dir path/to/run
+  python tests/stress/analyze_queue_pressure.py --run-dir path/to/run
+  ```
+
+## Postgres sampling
+
+`pg_prober.py` produces the prober JSONL the convoy and queue-pressure analyzers
+consume. It runs as its own process and samples a handful of cheap catalog views
+once per second, appending one timestamped JSON object per sample. The series it
+captures are the instrumentation for the lock-convoy hypothesis: `pg_stat_activity`
+backend counts by state and wait event, `pg_locks` counts by mode with granted
+and waiting kept separate, the `pg_stat_database` deadlocks counter, the current
+waiting-prompt backlog depth via an MVCC read that takes no row locks, per-relation
+tuple-lock counts for a tracked set of hot relations, and blocking chains derived
+from `pg_blocking_pids` with each blocker's state and transaction age. The
+sampling connection runs in autocommit with a short `statement_timeout` so a
+stalled sample cannot itself pile onto the backend under study.
+
+Its CLI defaults target a stack published on `localhost:15432`; point it at your
+own deployment with `--host`, `--port`, `--dbname`, `--user`, and `--password`.
+
+```
+python tests/stress/pg_prober.py --port 15432 --duration 300 > pg_prober.jsonl
+```
+

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 # Stress testing
 
 The `tests/stress/` suite drives a running AI Horde deployment with

--- a/tests/stress/analyze_hot_user_convoy.py
+++ b/tests/stress/analyze_hot_user_convoy.py
@@ -1,0 +1,434 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Correlate hot-user-convoy artifacts into a phase-aligned verdict.
+
+Reads the artifacts a hot-user-convoy run produces (the Locust CSV history, the
+Postgres prober JSONL carrying the lock-chain series, the before/after
+``pg_stat_statements`` snapshots, and the phase-boundary file) and buckets every
+series into the baseline, pressure, and relief phases. It then prints a
+phase-aligned timeline and a conclusion block that states, for each element of
+the lock-convoy signature, whether the run reproduced it:
+
+- tuple-lock queue depth on the ``users`` rows, and on the ``users.id = 0`` anon
+  row specifically (waiting ``FOR NO KEY UPDATE``),
+- blocking chains headed by ``idle in transaction`` sessions, and the age of the
+  oldest blocking transaction,
+- the ``FOR NO KEY UPDATE`` statement's windowed mean and cumulative max latency
+  from the ``pg_stat_statements`` delta,
+- pop and status latency per phase, and whether reads degraded less than writes,
+- and whether latency recovered once new work stopped in the relief phase.
+
+The verdict is descriptive: a partial reproduction is reported as exactly that,
+per element, rather than being rounded up to a confirmation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_POP = "[hc] pop"
+_SUBMIT = "[hc] submit"
+_ASYNC_ANON = "[hc] async anon"
+_ASYNC_HEAVY = "[hc] async heavy"
+_STATUS_POLL = "[hc] status poll"
+_KUDOS = "[hc] kudos transfer"
+_TRACKED_NAMES = [_POP, _SUBMIT, _ASYNC_ANON, _ASYNC_HEAVY, _STATUS_POLL, _KUDOS]
+
+_PHASE_ORDER = ["baseline", "pressure", "relief"]
+
+_FNKU_MARKER = "for no key update"
+
+
+@dataclass
+class _Phases:
+    run_start: float
+    baseline_start: float
+    pressure_start: float
+    relief_start: float
+    relief_end: float
+
+    def phase_of(self, ts: float) -> str | None:
+        if ts < self.baseline_start:
+            return None
+        if ts < self.pressure_start:
+            return "baseline"
+        if ts < self.relief_start:
+            return "pressure"
+        if ts < self.relief_end:
+            return "relief"
+        return None
+
+
+@dataclass
+class _LatencyStat:
+    medians: list[float] = field(default_factory=list)
+    p95s: list[float] = field(default_factory=list)
+    request_count_last: int = 0
+    request_count_first: int | None = None
+
+    def p50(self) -> float:
+        return statistics.median(self.medians) if self.medians else 0.0
+
+    def peak_p95(self) -> float:
+        return max(self.p95s) if self.p95s else 0.0
+
+    def requests(self) -> int:
+        if self.request_count_first is None:
+            return 0
+        return max(0, self.request_count_last - self.request_count_first)
+
+
+def _num(value: str | None) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _int(value: str | None) -> int | None:
+    n = _num(value)
+    return int(n) if n is not None else None
+
+
+def _load_phases(path: Path) -> _Phases:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return _Phases(
+        run_start=data["run_start"],
+        baseline_start=data["baseline_start"],
+        pressure_start=data["pressure_start"],
+        relief_start=data["relief_start"],
+        relief_end=data["relief_end"],
+    )
+
+
+def _load_latency(history_csv: Path, phases: _Phases) -> dict[str, dict[str, _LatencyStat]]:
+    """Return latency stats keyed by phase then request name from the CSV history."""
+    stats: dict[str, dict[str, _LatencyStat]] = {phase: {name: _LatencyStat() for name in _TRACKED_NAMES} for phase in _PHASE_ORDER}
+    if not history_csv.is_file():
+        return stats
+    with history_csv.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            name = row.get("Name", "")
+            if name not in _TRACKED_NAMES:
+                continue
+            try:
+                ts = float(row.get("Timestamp", "0"))
+            except ValueError:
+                continue
+            phase = phases.phase_of(ts)
+            if phase is None:
+                continue
+            stat = stats[phase][name]
+            median = _num(row.get("50%"))
+            p95 = _num(row.get("95%"))
+            if median is not None and (median > 0 or p95):
+                stat.medians.append(median)
+            if p95 is not None and p95 > 0:
+                stat.p95s.append(p95)
+            total = _int(row.get("Total Request Count"))
+            if total is not None:
+                if stat.request_count_first is None:
+                    stat.request_count_first = total
+                stat.request_count_last = total
+    return stats
+
+
+@dataclass
+class _ProberPhase:
+    active_sessions: list[int] = field(default_factory=list)
+    idle_in_transaction: list[int] = field(default_factory=list)
+    active_lock_waits: list[int] = field(default_factory=list)
+    users_tuple_lock_waiting: list[int] = field(default_factory=list)
+    users_fnku_waits: list[int] = field(default_factory=list)
+    users_fnku_id_zero_waits: list[int] = field(default_factory=list)
+    blocking_chain_count: list[int] = field(default_factory=list)
+    blocking_chains_idle_blocker: list[int] = field(default_factory=list)
+    max_blocker_xact_age_s: list[float] = field(default_factory=list)
+    deep_chain_example: dict | None = None
+
+    def mx(self, xs: list) -> float:
+        return max(xs) if xs else 0
+
+    def mean(self, xs: list) -> float:
+        return statistics.mean(xs) if xs else 0.0
+
+
+def _load_prober(prober_jsonl: Path, phases: _Phases) -> dict[str, _ProberPhase]:
+    """Return per-phase prober aggregates, including a deepest-chain exemplar."""
+    per_phase: dict[str, _ProberPhase] = {phase: _ProberPhase() for phase in _PHASE_ORDER}
+    if not prober_jsonl.is_file():
+        return per_phase
+    for line in prober_jsonl.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if "sample_error" in record:
+            continue
+        phase = phases.phase_of(float(record.get("ts", 0)))
+        if phase is None:
+            continue
+        bucket = per_phase[phase]
+        bucket.active_sessions.append(int(record.get("active_sessions", 0)))
+        bucket.idle_in_transaction.append(int(record.get("idle_in_transaction", 0)))
+        bucket.active_lock_waits.append(int(record.get("active_lock_waits", 0)))
+        bucket.users_tuple_lock_waiting.append(int(record.get("users_tuple_lock_waiting", 0)))
+        bucket.users_fnku_waits.append(int(record.get("users_fnku_waits", 0)))
+        bucket.users_fnku_id_zero_waits.append(int(record.get("users_fnku_id_zero_waits", 0)))
+        bucket.blocking_chain_count.append(int(record.get("blocking_chain_count", 0)))
+        bucket.blocking_chains_idle_blocker.append(int(record.get("blocking_chains_idle_blocker", 0)))
+        bucket.max_blocker_xact_age_s.append(float(record.get("max_blocker_xact_age_s", 0.0)))
+        # Keep the sample's fullest idle-blocker chain as an exemplar for the report.
+        for chain in record.get("blocking_chains", []):
+            if not chain.get("blocker_idle_in_transaction"):
+                continue
+            best = bucket.deep_chain_example
+            if best is None or float(chain.get("blocker_xact_age_s", 0)) > float(best.get("blocker_xact_age_s", 0)):
+                bucket.deep_chain_example = chain
+    return per_phase
+
+
+@dataclass
+class _StatementDelta:
+    calls: int
+    windowed_mean_ms: float
+    cumulative_max_ms: float
+
+
+def _load_statement_delta(before_path: Path, after_path: Path) -> _StatementDelta | None:
+    """Return the ``FOR NO KEY UPDATE`` statement delta from the two snapshots.
+
+    Windowed mean is the delta of total execution time over the delta of calls, so
+    it reflects only the run window. ``max_exec_time`` is a since-reset cumulative
+    high-water mark, so the after-snapshot value is reported as-is (labelled).
+    """
+    if not before_path.is_file() or not after_path.is_file():
+        return None
+    before = _index_statements(json.loads(before_path.read_text(encoding="utf-8")))
+    after = json.loads(after_path.read_text(encoding="utf-8"))
+    delta_calls = 0
+    delta_total_ms = 0.0
+    cumulative_max_ms = 0.0
+    for row in after:
+        query = (row.get("query") or "").lower()
+        if _FNKU_MARKER not in query:
+            continue
+        queryid = row.get("queryid")
+        prior = before.get(queryid, {"calls": 0, "total_exec_time": 0.0})
+        delta_calls += int(row.get("calls", 0)) - int(prior.get("calls", 0))
+        delta_total_ms += float(row.get("total_exec_time", 0.0)) - float(prior.get("total_exec_time", 0.0))
+        cumulative_max_ms = max(cumulative_max_ms, float(row.get("max_exec_time", 0.0)))
+    if delta_calls <= 0:
+        return _StatementDelta(calls=max(0, delta_calls), windowed_mean_ms=0.0, cumulative_max_ms=cumulative_max_ms)
+    return _StatementDelta(calls=delta_calls, windowed_mean_ms=delta_total_ms / delta_calls, cumulative_max_ms=cumulative_max_ms)
+
+
+def _index_statements(rows: list[dict]) -> dict:
+    return {row.get("queryid"): row for row in rows}
+
+
+def _fmt(value: float) -> str:
+    return f"{value:,.0f}"
+
+
+def _ratio(pressure: float, baseline: float) -> str:
+    if baseline <= 0:
+        return "n/a" if pressure <= 0 else "inf"
+    return f"{pressure / baseline:.1f}x"
+
+
+def _print_latency_table(latency: dict[str, dict[str, _LatencyStat]]) -> None:
+    print("\n" + "=" * 96)
+    print("PER-PHASE LATENCY (ms): p50 = median of interval medians, p95 = peak interval p95")
+    print("=" * 96)
+    print(f"{'request':<20}" + "".join(f"{phase:>24}" for phase in _PHASE_ORDER))
+    print(f"{'':<20}" + "".join(f"{'p50 / p95 / reqs':>24}" for _ in _PHASE_ORDER))
+    print("-" * 96)
+    for name in _TRACKED_NAMES:
+        cells = []
+        for phase in _PHASE_ORDER:
+            stat = latency[phase][name]
+            cells.append(f"{_fmt(stat.p50())} / {_fmt(stat.peak_p95())} / {stat.requests()}")
+        print(f"{name:<20}" + "".join(f"{cell:>24}" for cell in cells))
+    print("-" * 96)
+
+
+def _print_prober_table(prober: dict[str, _ProberPhase]) -> None:
+    print("\n" + "=" * 96)
+    print("PER-PHASE POSTGRES (max within phase unless noted)")
+    print("=" * 96)
+    rows = [
+        ("active sessions (max)", lambda b: b.mx(b.active_sessions)),
+        ("idle-in-txn (max)", lambda b: b.mx(b.idle_in_transaction)),
+        ("active lock-waits (max)", lambda b: b.mx(b.active_lock_waits)),
+        ("users tuple-lock waiting (max)", lambda b: b.mx(b.users_tuple_lock_waiting)),
+        ("users FOR-NO-KEY-UPDATE waits (max)", lambda b: b.mx(b.users_fnku_waits)),
+        ("users.id=0 FNKU waits (max)", lambda b: b.mx(b.users_fnku_id_zero_waits)),
+        ("blocking chains (max)", lambda b: b.mx(b.blocking_chain_count)),
+        ("chains w/ idle-in-txn blocker (max)", lambda b: b.mx(b.blocking_chains_idle_blocker)),
+        ("oldest blocking txn age s (max)", lambda b: round(b.mx(b.max_blocker_xact_age_s), 1)),
+    ]
+    print(f"{'metric':<38}" + "".join(f"{phase:>18}" for phase in _PHASE_ORDER))
+    print("-" * 96)
+    for label, getter in rows:
+        cells = "".join(f"{getter(prober[phase]):>18}" for phase in _PHASE_ORDER)
+        print(f"{label:<38}{cells}")
+    print("-" * 96)
+
+
+def _verdict(reproduced: bool, partial: bool) -> str:
+    if reproduced:
+        return "REPRODUCED"
+    if partial:
+        return "PARTIAL"
+    return "NOT REPRODUCED"
+
+
+def _print_conclusion(
+    latency: dict[str, dict[str, _LatencyStat]],
+    prober: dict[str, _ProberPhase],
+    statement_delta: _StatementDelta | None,
+) -> None:
+    def peak(phase: str, name: str) -> float:
+        return latency[phase][name].peak_p95()
+
+    base_pop = peak("baseline", _POP)
+    press_pop = peak("pressure", _POP)
+    relief_pop = peak("relief", _POP)
+    base_submit = peak("baseline", _SUBMIT)
+    press_submit = peak("pressure", _SUBMIT)
+    base_status = peak("baseline", _STATUS_POLL)
+    press_status = peak("pressure", _STATUS_POLL)
+
+    pop_ratio = (press_pop / base_pop) if base_pop > 0 else 0.0
+    submit_ratio = (press_submit / base_submit) if base_submit > 0 else 0.0
+    status_ratio = (press_status / base_status) if base_status > 0 else 0.0
+
+    press = prober["pressure"]
+    press_users_tuple = press.mx(press.users_tuple_lock_waiting)
+    press_users0 = press.mx(press.users_fnku_id_zero_waits)
+    press_fnku = press.mx(press.users_fnku_waits)
+    press_idle_chains = press.mx(press.blocking_chains_idle_blocker)
+    press_chain_depth = press.mx(press.blocking_chain_count)
+    press_oldest_txn = press.mx(press.max_blocker_xact_age_s)
+
+    # Signature elements. Thresholds separate a clear reproduction from a weaker
+    # partial so a partial is never rounded up to a confirmation.
+    users_tuple_queue = _verdict(press_users_tuple >= 5, press_users_tuple >= 1)
+    users0_queue = _verdict(press_users0 >= 3, press_users0 >= 1)
+    idle_chain = _verdict(press_idle_chains >= 3, press_idle_chains >= 1)
+    fnku_slow = "NOT REPRODUCED"
+    if statement_delta is not None:
+        fnku_slow = _verdict(
+            statement_delta.windowed_mean_ms >= 100 or statement_delta.cumulative_max_ms >= 5000,
+            statement_delta.windowed_mean_ms >= 20,
+        )
+    latency_blowup = _verdict(pop_ratio >= 3.0 or submit_ratio >= 3.0, pop_ratio >= 1.5 or submit_ratio >= 1.5)
+    status_spared = _verdict(
+        pop_ratio > 0 and status_ratio > 0 and pop_ratio >= status_ratio * 1.5,
+        pop_ratio > 0 and status_ratio >= 0 and pop_ratio > status_ratio,
+    )
+    recovery = _verdict(base_pop > 0 and relief_pop <= base_pop * 1.5, press_pop > 0 and relief_pop <= press_pop * 0.6)
+
+    print("\n" + "=" * 96)
+    print("SIGNATURE VERDICT")
+    print("=" * 96)
+    print(f"pop p95 baseline->pressure : {_fmt(base_pop)} -> {_fmt(press_pop)} ms ({_ratio(press_pop, base_pop)})")
+    print(f"submit p95 baseline->press : {_fmt(base_submit)} -> {_fmt(press_submit)} ms ({_ratio(press_submit, base_submit)})")
+    print(f"status p95 baseline->press : {_fmt(base_status)} -> {_fmt(press_status)} ms ({_ratio(press_status, base_status)})")
+    print(f"pop p95 relief             : {_fmt(relief_pop)} ms ({_ratio(relief_pop, base_pop)} vs baseline)")
+    print(f"users tuple-lock queue (press, max)   : {press_users_tuple}")
+    print(f"users.id=0 FNKU waits (press, max)     : {press_users0}")
+    print(f"users FNKU waits any-row (press, max)  : {press_fnku}")
+    print(f"blocking chain depth (press, max)      : {press_chain_depth}")
+    print(f"idle-in-txn-headed chains (press, max) : {press_idle_chains}")
+    print(f"oldest blocking txn age (press, max s) : {press_oldest_txn:.1f}")
+    if statement_delta is not None:
+        print(
+            f"FOR NO KEY UPDATE (delta)              : {statement_delta.calls} calls, "
+            f"windowed mean {statement_delta.windowed_mean_ms:.1f} ms, cumulative max {statement_delta.cumulative_max_ms:,.0f} ms",
+        )
+    else:
+        print("FOR NO KEY UPDATE (delta)              : pg_stat_statements snapshots MISSING")
+    print("-" * 96)
+    print(f"{'users-row tuple-lock queue':<40}: {users_tuple_queue}")
+    print(f"{'users.id=0 FNKU queue':<40}: {users0_queue}")
+    print(f"{'idle-in-txn-headed blocking chains':<40}: {idle_chain}")
+    print(f"{'FOR NO KEY UPDATE latency inflated':<40}: {fnku_slow}")
+    print(f"{'pop/submit latency blowup':<40}: {latency_blowup}")
+    print(f"{'status less affected than pop':<40}: {status_spared}")
+    print(f"{'recovery on relief':<40}: {recovery}")
+    print("-" * 96)
+
+    exemplar = press.deep_chain_example
+    if exemplar is not None:
+        print("\ndeepest idle-in-transaction blocking chain observed in the pressure phase:")
+        print(
+            f"  blocker pid {exemplar.get('blocker_pid')} state={exemplar.get('blocker_state')!r} "
+            f"xact_age={exemplar.get('blocker_xact_age_s')}s",
+        )
+        print(f"    blocker query: {(exemplar.get('blocker_query') or '')[:160]}")
+        print(f"  blocked pid {exemplar.get('blocked_pid')} wait={exemplar.get('blocked_wait')!r}")
+        print(f"    blocked query: {(exemplar.get('blocked_query') or '')[:160]}")
+
+    core = [users_tuple_queue, users0_queue, idle_chain, fnku_slow]
+    strong = core.count("REPRODUCED")
+    partial = core.count("PARTIAL")
+    print("\n" + "=" * 96)
+    if strong >= 3:
+        overall = "HOT-USER CONVOY REPRODUCED: the users-row lock-queue signature formed under pressure."
+    elif strong >= 1 or partial >= 2:
+        overall = "HOT-USER CONVOY PARTIALLY REPRODUCED: some signature elements formed; see per-element verdicts."
+    else:
+        overall = "HOT-USER CONVOY NOT REPRODUCED at these parameters."
+    print(overall)
+    print("=" * 96)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Analyze hot-user-convoy run artifacts into a verdict.")
+    parser.add_argument("--run-dir", required=True, help="Directory containing the run artifacts.")
+    parser.add_argument("--phases", default=None, help="Path to phases.json (defaults to <run-dir>/phases.json).")
+    args = parser.parse_args(argv)
+
+    run_dir = Path(args.run_dir)
+    phases_path = Path(args.phases) if args.phases else run_dir / "phases.json"
+    history_csv = run_dir / "hc_stats_history.csv"
+    prober_jsonl = run_dir / "pg_prober.jsonl"
+    before_path = run_dir / "pg_stat_statements_before.json"
+    after_path = run_dir / "pg_stat_statements_after.json"
+
+    if not phases_path.is_file():
+        print(f"ERROR: phases file not found: {phases_path}")
+        return 2
+
+    phases = _load_phases(phases_path)
+    latency = _load_latency(history_csv, phases)
+    prober = _load_prober(prober_jsonl, phases)
+    statement_delta = _load_statement_delta(before_path, after_path)
+
+    print(f"run dir     : {run_dir}")
+    print(f"history csv : {history_csv} ({'present' if history_csv.is_file() else 'MISSING'})")
+    print(f"prober jsonl: {prober_jsonl} ({'present' if prober_jsonl.is_file() else 'MISSING'})")
+    print(f"pgss snaps  : {'present' if before_path.is_file() and after_path.is_file() else 'MISSING'}")
+
+    _print_latency_table(latency)
+    _print_prober_table(prober)
+    _print_conclusion(latency, prober, statement_delta)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/stress/analyze_hot_user_convoy.py
+++ b/tests/stress/analyze_hot_user_convoy.py
@@ -15,6 +15,10 @@ the lock-convoy signature, whether the run reproduced it:
   row specifically (waiting ``FOR NO KEY UPDATE``),
 - blocking chains headed by ``idle in transaction`` sessions, and the age of the
   oldest blocking transaction,
+- migrated contention on the rows still updated inline (``user_stats`` and
+  ``user_records`` tuple-lock queue depth, and idle-in-transaction chains whose
+  blocker query targets those rows), reported separately so an A/B shows the old
+  users-row signature disappearing while a new one may or may not appear,
 - the ``FOR NO KEY UPDATE`` statement's windowed mean and cumulative max latency
   from the ``pg_stat_statements`` delta,
 - pop and status latency per phase, and whether reads degraded less than writes,
@@ -29,6 +33,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import re
 import statistics
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -44,6 +49,12 @@ _TRACKED_NAMES = [_POP, _SUBMIT, _ASYNC_ANON, _ASYNC_HEAVY, _STATUS_POLL, _KUDOS
 _PHASE_ORDER = ["baseline", "pressure", "relief"]
 
 _FNKU_MARKER = "for no key update"
+
+# Relations that would carry contention migrating off the users row. A blocker
+# query naming one of these, at the head of an idle-in-transaction chain, is the
+# post-fix signature the users-only classification cannot see.
+_USER_STATS_RE = re.compile(r"\buser_stats\b", re.IGNORECASE)
+_USER_RECORDS_RE = re.compile(r"\buser_records\b", re.IGNORECASE)
 
 
 @dataclass
@@ -150,10 +161,14 @@ class _ProberPhase:
     users_tuple_lock_waiting: list[int] = field(default_factory=list)
     users_fnku_waits: list[int] = field(default_factory=list)
     users_fnku_id_zero_waits: list[int] = field(default_factory=list)
+    user_stats_tuple_lock_waiting: list[int] = field(default_factory=list)
+    user_records_tuple_lock_waiting: list[int] = field(default_factory=list)
+    migrated_idle_chains: list[int] = field(default_factory=list)
     blocking_chain_count: list[int] = field(default_factory=list)
     blocking_chains_idle_blocker: list[int] = field(default_factory=list)
     max_blocker_xact_age_s: list[float] = field(default_factory=list)
     deep_chain_example: dict | None = None
+    migrated_chain_example: dict | None = None
 
     def mx(self, xs: list) -> float:
         return max(xs) if xs else 0
@@ -187,16 +202,32 @@ def _load_prober(prober_jsonl: Path, phases: _Phases) -> dict[str, _ProberPhase]
         bucket.users_tuple_lock_waiting.append(int(record.get("users_tuple_lock_waiting", 0)))
         bucket.users_fnku_waits.append(int(record.get("users_fnku_waits", 0)))
         bucket.users_fnku_id_zero_waits.append(int(record.get("users_fnku_id_zero_waits", 0)))
+        # Per-relation tuple-lock waits (absent on pre-migration artifacts -> 0).
+        by_rel = record.get("tuple_lock_waiting_by_relation", {}) or {}
+        bucket.user_stats_tuple_lock_waiting.append(int(by_rel.get("user_stats", 0)))
+        bucket.user_records_tuple_lock_waiting.append(int(by_rel.get("user_records", 0)))
         bucket.blocking_chain_count.append(int(record.get("blocking_chain_count", 0)))
         bucket.blocking_chains_idle_blocker.append(int(record.get("blocking_chains_idle_blocker", 0)))
         bucket.max_blocker_xact_age_s.append(float(record.get("max_blocker_xact_age_s", 0.0)))
-        # Keep the sample's fullest idle-blocker chain as an exemplar for the report.
+        # Keep the sample's fullest idle-blocker chain as an exemplar for the report,
+        # and count (plus keep an exemplar of) those whose blocker targets
+        # user_stats/user_records: the migrated-contention chain the users-row
+        # classification cannot flag.
+        migrated = 0
         for chain in record.get("blocking_chains", []):
             if not chain.get("blocker_idle_in_transaction"):
                 continue
+            age = float(chain.get("blocker_xact_age_s", 0))
             best = bucket.deep_chain_example
-            if best is None or float(chain.get("blocker_xact_age_s", 0)) > float(best.get("blocker_xact_age_s", 0)):
+            if best is None or age > float(best.get("blocker_xact_age_s", 0)):
                 bucket.deep_chain_example = chain
+            blocker_query = chain.get("blocker_query") or ""
+            if _USER_STATS_RE.search(blocker_query) or _USER_RECORDS_RE.search(blocker_query):
+                migrated += 1
+                mbest = bucket.migrated_chain_example
+                if mbest is None or age > float(mbest.get("blocker_xact_age_s", 0)):
+                    bucket.migrated_chain_example = chain
+        bucket.migrated_idle_chains.append(migrated)
     return per_phase
 
 
@@ -276,6 +307,9 @@ def _print_prober_table(prober: dict[str, _ProberPhase]) -> None:
         ("users tuple-lock waiting (max)", lambda b: b.mx(b.users_tuple_lock_waiting)),
         ("users FOR-NO-KEY-UPDATE waits (max)", lambda b: b.mx(b.users_fnku_waits)),
         ("users.id=0 FNKU waits (max)", lambda b: b.mx(b.users_fnku_id_zero_waits)),
+        ("user_stats tuple-lock waiting (max)", lambda b: b.mx(b.user_stats_tuple_lock_waiting)),
+        ("user_records tuple-lock waiting (max)", lambda b: b.mx(b.user_records_tuple_lock_waiting)),
+        ("migrated idle-in-txn chains (max)", lambda b: b.mx(b.migrated_idle_chains)),
         ("blocking chains (max)", lambda b: b.mx(b.blocking_chain_count)),
         ("chains w/ idle-in-txn blocker (max)", lambda b: b.mx(b.blocking_chains_idle_blocker)),
         ("oldest blocking txn age s (max)", lambda b: round(b.mx(b.max_blocker_xact_age_s), 1)),
@@ -323,12 +357,20 @@ def _print_conclusion(
     press_idle_chains = press.mx(press.blocking_chains_idle_blocker)
     press_chain_depth = press.mx(press.blocking_chain_count)
     press_oldest_txn = press.mx(press.max_blocker_xact_age_s)
+    press_user_stats_tuple = press.mx(press.user_stats_tuple_lock_waiting)
+    press_user_records_tuple = press.mx(press.user_records_tuple_lock_waiting)
+    press_migrated_chains = press.mx(press.migrated_idle_chains)
 
     # Signature elements. Thresholds separate a clear reproduction from a weaker
     # partial so a partial is never rounded up to a confirmation.
     users_tuple_queue = _verdict(press_users_tuple >= 5, press_users_tuple >= 1)
     users0_queue = _verdict(press_users0 >= 3, press_users0 >= 1)
     idle_chain = _verdict(press_idle_chains >= 3, press_idle_chains >= 1)
+    # Migrated-contention elements reuse the users-row thresholds so a shift onto
+    # the sibling rows reads on the same scale as the signature it replaces.
+    user_stats_queue = _verdict(press_user_stats_tuple >= 5, press_user_stats_tuple >= 1)
+    user_records_queue = _verdict(press_user_records_tuple >= 5, press_user_records_tuple >= 1)
+    migrated_chain = _verdict(press_migrated_chains >= 3, press_migrated_chains >= 1)
     fnku_slow = "NOT REPRODUCED"
     if statement_delta is not None:
         fnku_slow = _verdict(
@@ -372,6 +414,18 @@ def _print_conclusion(
     print(f"{'recovery on relief':<40}: {recovery}")
     print("-" * 96)
 
+    # Migrated-contention watch: reported separately from the users-row verdict so
+    # an A/B shows the old signature disappearing while a new one may appear on the
+    # rows still updated inline. These do not feed the overall convoy verdict.
+    print("MIGRATED CONTENTION (rows still updated inline: user_stats / user_records)")
+    print(f"user_stats tuple-lock queue (press, max)   : {press_user_stats_tuple}")
+    print(f"user_records tuple-lock queue (press, max) : {press_user_records_tuple}")
+    print(f"migrated idle-in-txn chains (press, max)   : {press_migrated_chains}")
+    print(f"{'user_stats tuple-lock queue':<40}: {user_stats_queue}")
+    print(f"{'user_records tuple-lock queue':<40}: {user_records_queue}")
+    print(f"{'idle-in-txn chains on stats/records':<40}: {migrated_chain}")
+    print("-" * 96)
+
     exemplar = press.deep_chain_example
     if exemplar is not None:
         print("\ndeepest idle-in-transaction blocking chain observed in the pressure phase:")
@@ -382,6 +436,17 @@ def _print_conclusion(
         print(f"    blocker query: {(exemplar.get('blocker_query') or '')[:160]}")
         print(f"  blocked pid {exemplar.get('blocked_pid')} wait={exemplar.get('blocked_wait')!r}")
         print(f"    blocked query: {(exemplar.get('blocked_query') or '')[:160]}")
+
+    migrated_exemplar = press.migrated_chain_example
+    if migrated_exemplar is not None:
+        print("\ndeepest idle-in-transaction chain whose blocker targets user_stats/user_records:")
+        print(
+            f"  blocker pid {migrated_exemplar.get('blocker_pid')} state={migrated_exemplar.get('blocker_state')!r} "
+            f"xact_age={migrated_exemplar.get('blocker_xact_age_s')}s",
+        )
+        print(f"    blocker query: {(migrated_exemplar.get('blocker_query') or '')[:160]}")
+        print(f"  blocked pid {migrated_exemplar.get('blocked_pid')} wait={migrated_exemplar.get('blocked_wait')!r}")
+        print(f"    blocked query: {(migrated_exemplar.get('blocked_query') or '')[:160]}")
 
     core = [users_tuple_queue, users0_queue, idle_chain, fnku_slow]
     strong = core.count("REPRODUCED")

--- a/tests/stress/analyze_hot_user_convoy.py
+++ b/tests/stress/analyze_hot_user_convoy.py
@@ -462,6 +462,39 @@ def _print_conclusion(
     print("=" * 96)
 
 
+def _print_population_health(stats_csv: Path) -> bool:
+    """Report per-population failure rates; return False when the run is invalid.
+
+    A population failing wholesale (for example every anonymous request 401ing
+    because the seeded key hash predates the current salt) silently removes its
+    load from the measured signature while every downstream verdict still
+    renders. Surface it as a loud invalid-run banner so a broken run is never
+    mistaken for a clean one.
+    """
+    if not stats_csv.is_file():
+        print(f"WARNING: {stats_csv} missing; cannot check population health")
+        return True
+    broken: list[tuple[str, int, int]] = []
+    with stats_csv.open(encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            name = row.get("Name", "")
+            if name == "Aggregated":
+                continue
+            requests = int(row.get("Request Count", 0) or 0)
+            failures = int(row.get("Failure Count", 0) or 0)
+            if requests >= 50 and failures / requests > 0.5:
+                broken.append((name, failures, requests))
+    if not broken:
+        return True
+    print("=" * 96)
+    print("INVALID RUN: population(s) failing wholesale; their load is ABSENT from the signature")
+    for name, failures, requests in broken:
+        print(f"  {name}: {failures}/{requests} failed")
+    print("  Fix the failing population and rerun; verdicts below describe a DIFFERENT scenario.")
+    print("=" * 96)
+    return False
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Analyze hot-user-convoy run artifacts into a verdict.")
     parser.add_argument("--run-dir", required=True, help="Directory containing the run artifacts.")
@@ -489,10 +522,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"prober jsonl: {prober_jsonl} ({'present' if prober_jsonl.is_file() else 'MISSING'})")
     print(f"pgss snaps  : {'present' if before_path.is_file() and after_path.is_file() else 'MISSING'}")
 
+    healthy = _print_population_health(run_dir / "hc_stats.csv")
     _print_latency_table(latency)
     _print_prober_table(prober)
     _print_conclusion(latency, prober, statement_delta)
-    return 0
+    return 0 if healthy else 3
 
 
 if __name__ == "__main__":

--- a/tests/stress/analyze_queue_pressure.py
+++ b/tests/stress/analyze_queue_pressure.py
@@ -353,7 +353,11 @@ def _print_conclusion(
     print(f"{'recovery on relief':<40}: {recovery}")
     print("-" * 96)
 
-    for label, lines in (("deadlock detected", pg_findings["deadlock"]), ("lock waits", pg_findings["lock_wait"]), ("connection exhaustion", pg_findings["too_many_connections"])):
+    for label, lines in (
+        ("deadlock detected", pg_findings["deadlock"]),
+        ("lock waits", pg_findings["lock_wait"]),
+        ("connection exhaustion", pg_findings["too_many_connections"]),
+    ):
         if lines:
             print(f"\npg-log evidence [{label}] (up to 8 lines):")
             for entry in lines:

--- a/tests/stress/analyze_queue_pressure.py
+++ b/tests/stress/analyze_queue_pressure.py
@@ -1,0 +1,408 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Correlate queue-pressure artifacts into a phase-aligned verdict.
+
+Reads the artifacts a queue-pressure run produces (the Locust CSV history, the
+Postgres prober JSONL, the Postgres container log, and the phase-boundary file)
+and buckets every series into the baseline, pressure, and relief phases. It then
+prints a phase-aligned timeline table and a conclusion block that states, for
+each element of the lock-convoy signature, whether the run reproduced it:
+
+- pop/submit latency blowup relative to baseline,
+- active-session and RowShareLock spikes tracking the backlog,
+- deadlocks confined to the pressure window (prober counter delta and log grep),
+- whether status reads degraded less than worker writes,
+- and whether latency recovered once inflation stopped in the relief phase.
+
+The verdict is descriptive: it reports which elements reproduced and which did
+not, so a partial reproduction is presented as exactly that rather than being
+rounded up to a confirmation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_POP = "[qp] pop"
+_SUBMIT = "[qp] submit"
+_ASYNC_SERVED = "[qp] async served"
+_ASYNC_BACKLOG = "[qp] async backlog"
+_STATUS = "[qp] status served"
+_TRACKED_NAMES = [_POP, _SUBMIT, _ASYNC_SERVED, _ASYNC_BACKLOG, _STATUS]
+
+_PHASE_ORDER = ["baseline", "pressure", "relief"]
+
+
+@dataclass
+class _Phases:
+    run_start: float
+    baseline_start: float
+    pressure_start: float
+    relief_start: float
+    relief_end: float
+
+    def phase_of(self, ts: float) -> str | None:
+        if ts < self.baseline_start:
+            return None
+        if ts < self.pressure_start:
+            return "baseline"
+        if ts < self.relief_start:
+            return "pressure"
+        if ts < self.relief_end:
+            return "relief"
+        return None
+
+
+@dataclass
+class _LatencyStat:
+    medians: list[float] = field(default_factory=list)
+    p95s: list[float] = field(default_factory=list)
+    request_count_last: int = 0
+    request_count_first: int | None = None
+
+    def p50(self) -> float:
+        return statistics.median(self.medians) if self.medians else 0.0
+
+    def peak_p95(self) -> float:
+        return max(self.p95s) if self.p95s else 0.0
+
+    def requests(self) -> int:
+        if self.request_count_first is None:
+            return 0
+        return max(0, self.request_count_last - self.request_count_first)
+
+
+def _load_phases(path: Path) -> _Phases:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return _Phases(
+        run_start=data["run_start"],
+        baseline_start=data["baseline_start"],
+        pressure_start=data["pressure_start"],
+        relief_start=data["relief_start"],
+        relief_end=data["relief_end"],
+    )
+
+
+def _load_latency(history_csv: Path, phases: _Phases) -> dict[str, dict[str, _LatencyStat]]:
+    """Return latency stats keyed by phase then request name from the CSV history."""
+    stats: dict[str, dict[str, _LatencyStat]] = {phase: {name: _LatencyStat() for name in _TRACKED_NAMES} for phase in _PHASE_ORDER}
+    if not history_csv.is_file():
+        return stats
+    with history_csv.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            name = row.get("Name", "")
+            if name not in _TRACKED_NAMES:
+                continue
+            try:
+                ts = float(row.get("Timestamp", "0"))
+            except ValueError:
+                continue
+            phase = phases.phase_of(ts)
+            if phase is None:
+                continue
+            stat = stats[phase][name]
+            median = _num(row.get("50%"))
+            p95 = _num(row.get("95%"))
+            # Snapshot percentile columns are blank when that name saw no traffic
+            # in the interval; only fold in populated samples.
+            if median is not None and (median > 0 or p95):
+                stat.medians.append(median)
+            if p95 is not None and p95 > 0:
+                stat.p95s.append(p95)
+            total = _int(row.get("Total Request Count"))
+            if total is not None:
+                if stat.request_count_first is None:
+                    stat.request_count_first = total
+                stat.request_count_last = total
+    return stats
+
+
+def _num(value: str | None) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _int(value: str | None) -> int | None:
+    n = _num(value)
+    return int(n) if n is not None else None
+
+
+@dataclass
+class _ProberPhase:
+    active_sessions: list[int] = field(default_factory=list)
+    idle_in_transaction: list[int] = field(default_factory=list)
+    rowsharelock_granted: list[int] = field(default_factory=list)
+    rowsharelock_waiting: list[int] = field(default_factory=list)
+    locks_waiting_total: list[int] = field(default_factory=list)
+    active_lock_waits: list[int] = field(default_factory=list)
+    backlog_text: list[int] = field(default_factory=list)
+    deadlocks_last: int = 0
+    deadlocks_first: int | None = None
+
+    def _mx(self, xs: list[int]) -> int:
+        return max(xs) if xs else 0
+
+    def _mean(self, xs: list[int]) -> float:
+        return statistics.mean(xs) if xs else 0.0
+
+    def deadlock_delta(self) -> int:
+        if self.deadlocks_first is None:
+            return 0
+        return max(0, self.deadlocks_last - self.deadlocks_first)
+
+
+def _load_prober(prober_jsonl: Path, phases: _Phases) -> tuple[dict[str, _ProberPhase], int]:
+    """Return per-phase prober aggregates and the whole-run deadlock delta."""
+    per_phase: dict[str, _ProberPhase] = {phase: _ProberPhase() for phase in _PHASE_ORDER}
+    first_deadlocks: int | None = None
+    last_deadlocks = 0
+    if not prober_jsonl.is_file():
+        return per_phase, 0
+    for line in prober_jsonl.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if "sample_error" in record:
+            continue
+        deadlocks = int(record.get("deadlocks", 0))
+        if first_deadlocks is None:
+            first_deadlocks = deadlocks
+        last_deadlocks = deadlocks
+        ts = float(record.get("ts", 0))
+        phase = phases.phase_of(ts)
+        if phase is None:
+            continue
+        bucket = per_phase[phase]
+        bucket.active_sessions.append(int(record.get("active_sessions", 0)))
+        bucket.idle_in_transaction.append(int(record.get("idle_in_transaction", 0)))
+        bucket.rowsharelock_granted.append(int(record.get("rowsharelock_granted", 0)))
+        bucket.rowsharelock_waiting.append(int(record.get("rowsharelock_waiting", 0)))
+        bucket.locks_waiting_total.append(int(record.get("locks_waiting_total", 0)))
+        bucket.active_lock_waits.append(int(record.get("active_lock_waits", 0)))
+        bucket.backlog_text.append(int(record.get("backlog_text", 0)))
+        if bucket.deadlocks_first is None:
+            bucket.deadlocks_first = deadlocks
+        bucket.deadlocks_last = deadlocks
+    whole_run_delta = 0 if first_deadlocks is None else max(0, last_deadlocks - first_deadlocks)
+    return per_phase, whole_run_delta
+
+
+def _grep_pg_log(postgres_log: Path) -> dict[str, list[str]]:
+    """Grep the Postgres container log for deadlock and lock-wait evidence."""
+    findings: dict[str, list[str]] = {"deadlock": [], "lock_wait": [], "too_many_connections": []}
+    if not postgres_log.is_file():
+        return findings
+    patterns = {
+        "deadlock": re.compile(r"deadlock detected", re.IGNORECASE),
+        "lock_wait": re.compile(r"still waiting for|process \d+ (still )?waiting", re.IGNORECASE),
+        "too_many_connections": re.compile(r"too many clients|remaining connection slots|sorry, too many", re.IGNORECASE),
+    }
+    for line in postgres_log.read_text(encoding="utf-8", errors="replace").splitlines():
+        for key, pattern in patterns.items():
+            if pattern.search(line):
+                if len(findings[key]) < 8:
+                    findings[key].append(line.strip())
+    return findings
+
+
+def _fmt(value: float) -> str:
+    return f"{value:,.0f}"
+
+
+def _ratio(pressure: float, baseline: float) -> str:
+    if baseline <= 0:
+        return "n/a" if pressure <= 0 else "inf"
+    return f"{pressure / baseline:.1f}x"
+
+
+def _print_latency_table(latency: dict[str, dict[str, _LatencyStat]]) -> None:
+    print("\n" + "=" * 96)
+    print("PER-PHASE LATENCY (ms): p50 = median of interval medians, p95 = peak interval p95")
+    print("=" * 96)
+    header = f"{'request':<20}" + "".join(f"{phase:>24}" for phase in _PHASE_ORDER)
+    print(header)
+    print(f"{'':<20}" + "".join(f"{'p50 / p95 / reqs':>24}" for _ in _PHASE_ORDER))
+    print("-" * 96)
+    for name in _TRACKED_NAMES:
+        cells = []
+        for phase in _PHASE_ORDER:
+            stat = latency[phase][name]
+            cells.append(f"{_fmt(stat.p50())} / {_fmt(stat.peak_p95())} / {stat.requests()}")
+        print(f"{name:<20}" + "".join(f"{cell:>24}" for cell in cells))
+    print("-" * 96)
+
+
+def _print_prober_table(prober: dict[str, _ProberPhase]) -> None:
+    print("\n" + "=" * 96)
+    print("PER-PHASE POSTGRES (max within phase unless noted)")
+    print("=" * 96)
+    rows = [
+        ("active sessions (max)", lambda b: b._mx(b.active_sessions)),
+        ("active sessions (mean)", lambda b: round(b._mean(b.active_sessions), 1)),
+        ("idle-in-txn (max)", lambda b: b._mx(b.idle_in_transaction)),
+        ("RowShareLock granted (max)", lambda b: b._mx(b.rowsharelock_granted)),
+        ("RowShareLock waiting (max)", lambda b: b._mx(b.rowsharelock_waiting)),
+        ("locks waiting total (max)", lambda b: b._mx(b.locks_waiting_total)),
+        ("active lock-waits (max)", lambda b: b._mx(b.active_lock_waits)),
+        ("text backlog (max)", lambda b: b._mx(b.backlog_text)),
+        ("deadlock delta (phase)", lambda b: b.deadlock_delta()),
+    ]
+    header = f"{'metric':<30}" + "".join(f"{phase:>18}" for phase in _PHASE_ORDER)
+    print(header)
+    print("-" * 96)
+    for label, getter in rows:
+        cells = "".join(f"{getter(prober[phase]):>18}" for phase in _PHASE_ORDER)
+        print(f"{label:<30}{cells}")
+    print("-" * 96)
+
+
+def _print_conclusion(
+    latency: dict[str, dict[str, _LatencyStat]],
+    prober: dict[str, _ProberPhase],
+    whole_run_deadlock_delta: int,
+    pg_findings: dict[str, list[str]],
+) -> None:
+    def peak(phase: str, name: str) -> float:
+        return latency[phase][name].peak_p95()
+
+    base_pop = peak("baseline", _POP)
+    press_pop = peak("pressure", _POP)
+    relief_pop = peak("relief", _POP)
+    base_submit = peak("baseline", _SUBMIT)
+    press_submit = peak("pressure", _SUBMIT)
+    base_status = peak("baseline", _STATUS)
+    press_status = peak("pressure", _STATUS)
+
+    pop_ratio = (press_pop / base_pop) if base_pop > 0 else 0.0
+    submit_ratio = (press_submit / base_submit) if base_submit > 0 else 0.0
+    status_ratio = (press_status / base_status) if base_status > 0 else 0.0
+
+    base_sessions = prober["baseline"]._mx(prober["baseline"].active_sessions)
+    press_sessions = prober["pressure"]._mx(prober["pressure"].active_sessions)
+    base_rsl = prober["baseline"]._mx(prober["baseline"].rowsharelock_granted)
+    press_rsl = prober["pressure"]._mx(prober["pressure"].rowsharelock_granted)
+    press_backlog = prober["pressure"]._mx(prober["pressure"].backlog_text)
+    press_lock_waits = prober["pressure"]._mx(prober["pressure"].active_lock_waits)
+
+    # Signature element decisions. "reproduced" uses a strong threshold, "partial"
+    # a weaker one, so a partial reproduction is never rounded up to a yes.
+    def verdict(reproduced: bool, partial: bool) -> str:
+        if reproduced:
+            return "REPRODUCED"
+        if partial:
+            return "PARTIAL"
+        return "not seen"
+
+    latency_blowup = verdict(pop_ratio >= 3.0 or submit_ratio >= 3.0, pop_ratio >= 1.5 or submit_ratio >= 1.5)
+    sessions_spike = verdict(
+        press_sessions >= max(base_sessions * 1.5, base_sessions + 8),
+        press_sessions >= base_sessions + 3,
+    )
+    rsl_spike = verdict(
+        press_rsl >= max(base_rsl * 1.5, base_rsl + 8),
+        press_rsl >= base_rsl + 3,
+    )
+    deadlocks_seen = whole_run_deadlock_delta > 0 or bool(pg_findings["deadlock"])
+    deadlock_verdict = "REPRODUCED" if deadlocks_seen else "not seen"
+    lock_waits_seen = press_lock_waits > 0 or bool(pg_findings["lock_wait"])
+    status_spared = verdict(
+        (pop_ratio > 0 and status_ratio > 0 and pop_ratio >= status_ratio * 1.5),
+        (pop_ratio > 0 and status_ratio >= 0 and pop_ratio > status_ratio),
+    )
+    recovery = verdict(
+        (base_pop > 0 and relief_pop <= base_pop * 1.5),
+        (press_pop > 0 and relief_pop <= press_pop * 0.6),
+    )
+
+    print("\n" + "=" * 96)
+    print("SIGNATURE VERDICT")
+    print("=" * 96)
+    print(f"pop p95 baseline->pressure : {_fmt(base_pop)} -> {_fmt(press_pop)} ms ({_ratio(press_pop, base_pop)})")
+    print(f"submit p95 baseline->press : {_fmt(base_submit)} -> {_fmt(press_submit)} ms ({_ratio(press_submit, base_submit)})")
+    print(f"status p95 baseline->press : {_fmt(base_status)} -> {_fmt(press_status)} ms ({_ratio(press_status, base_status)})")
+    print(f"pop p95 relief             : {_fmt(relief_pop)} ms ({_ratio(relief_pop, base_pop)} vs baseline)")
+    print(f"active sessions base->press: {base_sessions} -> {press_sessions}")
+    print(f"RowShareLock base->press   : {base_rsl} -> {press_rsl}")
+    print(f"text backlog peak (press)  : {press_backlog}")
+    print(f"lock-waits peak (press)    : {press_lock_waits} (pg-log lock-wait lines: {len(pg_findings['lock_wait'])})")
+    print(f"deadlock delta (whole run) : {whole_run_deadlock_delta} (pg-log deadlock lines: {len(pg_findings['deadlock'])})")
+    print(f"too-many-connections lines : {len(pg_findings['too_many_connections'])}")
+    print("-" * 96)
+    print(f"{'pop/submit latency blowup':<40}: {latency_blowup}")
+    print(f"{'active-session spike':<40}: {sessions_spike}")
+    print(f"{'RowShareLock spike':<40}: {rsl_spike}")
+    print(f"{'lock waiting present':<40}: {'yes' if lock_waits_seen else 'no'}")
+    print(f"{'deadlocks in window':<40}: {deadlock_verdict}")
+    print(f"{'status less affected than pop':<40}: {status_spared}")
+    print(f"{'recovery on relief':<40}: {recovery}")
+    print("-" * 96)
+
+    for label, lines in (("deadlock detected", pg_findings["deadlock"]), ("lock waits", pg_findings["lock_wait"]), ("connection exhaustion", pg_findings["too_many_connections"])):
+        if lines:
+            print(f"\npg-log evidence [{label}] (up to 8 lines):")
+            for entry in lines:
+                print(f"  {entry}")
+
+    strong = [latency_blowup, sessions_spike, rsl_spike].count("REPRODUCED") + (1 if deadlocks_seen else 0)
+    partial = [latency_blowup, sessions_spike, rsl_spike].count("PARTIAL")
+    print("\n" + "=" * 96)
+    if strong >= 3:
+        overall = "HYPOTHESIS SUPPORTED: multiple signature elements reproduced together."
+    elif strong >= 1 or partial >= 2:
+        overall = "HYPOTHESIS PARTIALLY SUPPORTED: some elements reproduced; see per-element verdicts."
+    else:
+        overall = "HYPOTHESIS NOT REPRODUCED at these parameters."
+    print(overall)
+    print("=" * 96)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Analyze queue-pressure run artifacts into a verdict.")
+    parser.add_argument("--run-dir", required=True, help="Directory containing the run artifacts.")
+    parser.add_argument("--phases", default=None, help="Path to phases.json (defaults to <run-dir>/phases.json).")
+    args = parser.parse_args(argv)
+
+    run_dir = Path(args.run_dir)
+    phases_path = Path(args.phases) if args.phases else run_dir / "phases.json"
+    history_csv = run_dir / "qp_stats_history.csv"
+    prober_jsonl = run_dir / "pg_prober.jsonl"
+    postgres_log = run_dir / "postgres.log"
+
+    if not phases_path.is_file():
+        print(f"ERROR: phases file not found: {phases_path}")
+        return 2
+
+    phases = _load_phases(phases_path)
+    latency = _load_latency(history_csv, phases)
+    prober, whole_run_deadlock_delta = _load_prober(prober_jsonl, phases)
+    pg_findings = _grep_pg_log(postgres_log)
+
+    print(f"run dir     : {run_dir}")
+    print(f"history csv : {history_csv} ({'present' if history_csv.is_file() else 'MISSING'})")
+    print(f"prober jsonl: {prober_jsonl} ({'present' if prober_jsonl.is_file() else 'MISSING'})")
+    print(f"postgres log: {postgres_log} ({'present' if postgres_log.is_file() else 'MISSING'})")
+
+    _print_latency_table(latency)
+    _print_prober_table(prober)
+    _print_conclusion(latency, prober, whole_run_deadlock_delta, pg_findings)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/stress/check_attribution_results.py
+++ b/tests/stress/check_attribution_results.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Gate an attribution scenario run on oracle-violation evidence.
+
+The attribution Locust scenario records every consistency violation to a JSONL
+evidence file (one record per violation) and, redundantly, as a Locust
+request-event failure under an ``oracle:*`` name. This checker treats the JSONL
+evidence as the authority and supports two modes:
+
+- Default (post-fix gate): the run passes only if it observed zero oracle
+  violations. This is the assertion that the fixed server never produces the
+  inconsistent responses the scenario probes for.
+- ``--expect-violations`` (pre-fix elicitation gate): the run passes only if it
+  observed at least one oracle violation. This asserts that the scenario actually
+  elicited the defect against a server known to contain it; a run that elicited
+  nothing is a harness failure, not a success.
+
+When a Locust stats CSV is provided the checker additionally fails a run that
+drove zero requests, so a vacuous "no violations" result cannot pass the post-fix
+gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+_AGGREGATED_ROW_NAME = "Aggregated"
+_SAMPLE_LIMIT = 5
+
+
+def _read_evidence(evidence_path: Path) -> list[dict[str, object]]:
+    """Return the parsed JSONL violation records, skipping blank lines."""
+    if not evidence_path.is_file():
+        return []
+    records: list[dict[str, object]] = []
+    with evidence_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            records.append(json.loads(stripped))
+    return records
+
+
+def _read_request_count(stats_path: Path) -> int:
+    """Return the aggregated request count from a Locust ``*_stats.csv``."""
+    with stats_path.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            if row.get("Name") == _AGGREGATED_ROW_NAME:
+                return int(row.get("Request Count", "0") or "0")
+    return 0
+
+
+def _summarize(records: list[dict[str, object]]) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for record in records:
+        oracle = record.get("oracle")
+        counts[str(oracle)] += 1
+    return counts
+
+
+def _print_report(records: list[dict[str, object]], counts: Counter[str]) -> None:
+    print(f"Attribution oracle evidence: {len(records)} violation record(s).")
+    for oracle, count in sorted(counts.items()):
+        print(f"  {count:>5}x {oracle}")
+    for oracle in sorted(counts):
+        samples = [record for record in records if str(record.get("oracle")) == oracle][:_SAMPLE_LIMIT]
+        if not samples:
+            continue
+        print(f"--- sample evidence for {oracle} (up to {_SAMPLE_LIMIT}) ---", file=sys.stderr)
+        for sample in samples:
+            print(f"  {json.dumps(sample, sort_keys=True)}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Gate an attribution scenario run on oracle-violation evidence.")
+    parser.add_argument("--evidence", required=True, type=Path, help="Path to the JSONL oracle-evidence file.")
+    parser.add_argument(
+        "--stats",
+        type=Path,
+        default=None,
+        help="Optional Locust <prefix>_stats.csv; when given, a zero-request run fails.",
+    )
+    parser.add_argument(
+        "--expect-violations",
+        action="store_true",
+        help="Pre-fix mode: require at least one violation (exit nonzero if none were elicited).",
+    )
+    args = parser.parse_args(argv)
+
+    records = _read_evidence(args.evidence)
+    counts = _summarize(records)
+    _print_report(records, counts)
+
+    if args.stats is not None:
+        if not args.stats.is_file():
+            raise SystemExit(f"Stats file not found: {args.stats}")
+        request_count = _read_request_count(args.stats)
+        print(f"Locust drove {request_count} request(s).")
+        if request_count <= 0:
+            raise SystemExit("Attribution run drove zero requests; the workload never reached the target.")
+
+    total = len(records)
+    if args.expect_violations:
+        if total == 0:
+            raise SystemExit(
+                "Elicitation gate FAILED: expected at least one oracle violation but the run recorded none.",
+            )
+        print(f"Elicitation gate passed: {total} oracle violation(s) were elicited as expected.")
+        return 0
+
+    if total > 0:
+        raise SystemExit(f"Consistency gate FAILED: the run recorded {total} oracle violation(s); see evidence above.")
+    print("Consistency gate passed: no oracle violations were recorded.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/stress/locustfile_attribution.py
+++ b/tests/stress/locustfile_attribution.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Locust entrypoint for the attribution and possibility consistency scenarios.
+
+This entrypoint spawns only the adversarial-timing text users defined in
+``locustsuite.users.attribution`` and reuses the suite's existing key-bootstrap
+and target-preflight events. The scenarios are driven with fixed per-class user
+counts derived from a small set of CLI arguments so a run reproduces the same
+adversarial shape every time.
+
+Usage:
+    locust -f tests/stress/locustfile_attribution.py --host http://localhost:7001 \
+        --headless --users 40 --spawn-rate 20 --run-time 150s \
+        --attribution-pairs 6 --maintenance-workers 2 \
+        --attribution-evidence attribution_evidence.jsonl --csv attribution
+"""
+# ruff: noqa: I001
+
+from __future__ import annotations
+
+from locust import events
+
+# Import the suite events module for its side effects: it registers the shared
+# CLI arguments, the key-bootstrap and target-preflight test_start handler. It
+# must be imported before the attribution test_start handler below so that key
+# bootstrap runs first.
+from locustsuite import events as _suite_events  # noqa: F401
+from locustsuite.ground_truth import oracle_recorder, reset_run_state
+from locustsuite.users.attribution import (
+    AttributionRequester,
+    MaintenanceFlipRequester,
+    MaintenanceFlipWorker,
+    PairedFlappingWorker,
+)
+
+__all__ = [
+    "AttributionRequester",
+    "MaintenanceFlipRequester",
+    "MaintenanceFlipWorker",
+    "PairedFlappingWorker",
+]
+
+
+@events.init_command_line_parser.add_listener
+def _add_attribution_arguments(parser) -> None:
+    group = parser.add_argument_group("AI Horde Attribution Scenario")
+    group.add_argument(
+        "--attribution-pairs",
+        type=int,
+        env_var="HORDE_ATTRIBUTION_PAIRS",
+        default=6,
+        help="Number of flapping worker pairs (each pair spawns two PairedFlappingWorker users).",
+    )
+    group.add_argument(
+        "--attribution-requestors",
+        type=int,
+        env_var="HORDE_ATTRIBUTION_REQUESTORS",
+        default=0,
+        help="Number of AttributionRequester users (0 derives 2 per pair).",
+    )
+    group.add_argument(
+        "--attribution-decoys",
+        type=int,
+        env_var="HORDE_ATTRIBUTION_DECOYS",
+        default=2,
+        help="Decoy models appended to each request's model constraint (models no worker declares).",
+    )
+    group.add_argument(
+        "--attribution-churn-period",
+        type=float,
+        env_var="HORDE_ATTRIBUTION_CHURN_PERIOD",
+        default=20.0,
+        help="Seconds between churns onto a fresh worker identity (0 disables churn).",
+    )
+    group.add_argument(
+        "--attribution-max-length",
+        type=int,
+        env_var="HORDE_ATTRIBUTION_MAX_LENGTH",
+        default=24,
+        help="max_length for attribution requests; kept small so jobs cycle quickly.",
+    )
+    group.add_argument(
+        "--maintenance-workers",
+        type=int,
+        env_var="HORDE_MAINTENANCE_WORKERS",
+        default=2,
+        help="Number of MaintenanceFlipWorker users (each owns a unique model).",
+    )
+    group.add_argument(
+        "--maintenance-requesters",
+        type=int,
+        env_var="HORDE_MAINTENANCE_REQUESTERS",
+        default=0,
+        help="Number of MaintenanceFlipRequester users (0 derives 2 per maintenance worker).",
+    )
+    group.add_argument(
+        "--maintenance-cycles",
+        type=int,
+        env_var="HORDE_MAINTENANCE_CYCLES",
+        default=0,
+        help="Pop/maintenance/release cycles per maintenance worker (0 for unbounded within the run).",
+    )
+    group.add_argument(
+        "--maintenance-hold-min",
+        type=float,
+        env_var="HORDE_MAINTENANCE_HOLD_MIN",
+        default=6.0,
+        help="Minimum seconds a maintenance worker holds a popped job in flight while in maintenance.",
+    )
+    group.add_argument(
+        "--maintenance-hold-max",
+        type=float,
+        env_var="HORDE_MAINTENANCE_HOLD_MAX",
+        default=12.0,
+        help="Maximum seconds a maintenance worker holds a popped job in flight while in maintenance.",
+    )
+    group.add_argument(
+        "--attribution-evidence",
+        type=str,
+        env_var="HORDE_ATTRIBUTION_EVIDENCE",
+        default="attribution_evidence.jsonl",
+        help="Path to the JSONL oracle-evidence file written when a consistency violation is observed.",
+    )
+
+
+@events.test_start.add_listener
+def _configure_attribution_run(environment, **_kwargs) -> None:
+    opts = environment.parsed_options
+
+    # Start each run from a clean registry so timelines and slot counters never
+    # carry over between runs sharing one process.
+    reset_run_state()
+    oracle_recorder.configure(opts.attribution_evidence)
+
+    pairs = max(int(opts.attribution_pairs), 0)
+    attribution_requestors = int(opts.attribution_requestors) or (pairs * 2)
+    maintenance_workers = max(int(opts.maintenance_workers), 0)
+    maintenance_requesters = int(opts.maintenance_requesters) or (maintenance_workers * 2)
+
+    PairedFlappingWorker.fixed_count = pairs * 2
+    AttributionRequester.fixed_count = attribution_requestors
+    MaintenanceFlipWorker.fixed_count = maintenance_workers
+    MaintenanceFlipRequester.fixed_count = maintenance_requesters

--- a/tests/stress/locustfile_hot_user_convoy.py
+++ b/tests/stress/locustfile_hot_user_convoy.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Locust entrypoint for the hot-user lock-convoy simulation.
+
+Spawns the convoy populations (``AnonRequester``, ``HeavyProxyRequester``,
+``ConvoyWorker``, ``StatusCheckPoller``, ``KudosTransfer``) with fixed per-class
+counts derived from CLI arguments, and configures the shared phase schedule and
+generation fan-out at test start. It reuses the suite's key-parsing and
+target-preflight ``test_start`` handler by importing ``locustsuite.events`` for
+its side effects; that import must precede the configuration handler below so
+keys are parsed first.
+
+Usage:
+    locust -f tests/stress/locustfile_hot_user_convoy.py --host http://localhost:80 \
+        --headless --users 120 --spawn-rate 60 --run-time 300s \
+        --hc-anon-requestors 60 --hc-heavy-requestors 6 --hc-workers 40 \
+        --hc-status-pollers 12 --hc-kudos-users 2 \
+        --hc-baseline 60 --hc-pressure 180 --hc-relief 60 \
+        --hc-n-pressure 6 --worker-api-keys W1,W2,... \
+        --hc-heavy-api-keys H1,... --hc-kudos-api-keys K1,K2 \
+        --csv hc --csv-full-history
+"""
+# ruff: noqa: I001
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from locust import events
+
+from locustsuite import events as _suite_events  # noqa: F401
+from locustsuite.helpers import _parse_csv
+from locustsuite.users.hot_user_convoy import (
+    AnonRequester,
+    ConvoyWorker,
+    HeavyProxyRequester,
+    KudosTransfer,
+    StatusCheckPoller,
+    configure_convoy,
+    convoy_state,
+)
+
+__all__ = ["AnonRequester", "ConvoyWorker", "HeavyProxyRequester", "KudosTransfer", "StatusCheckPoller"]
+
+
+@events.init_command_line_parser.add_listener
+def _add_convoy_arguments(parser) -> None:
+    group = parser.add_argument_group("AI Horde Hot User Convoy Scenario")
+    group.add_argument(
+        "--hc-anon-requestors",
+        type=int,
+        env_var="HC_ANON_REQUESTORS",
+        default=60,
+        help="Concurrent AnonRequester users (users.id=0 activations).",
+    )
+    group.add_argument(
+        "--hc-heavy-requestors",
+        type=int,
+        env_var="HC_HEAVY_REQUESTORS",
+        default=6,
+        help="Concurrent HeavyProxyRequester users (registered high-concurrency accounts).",
+    )
+    group.add_argument(
+        "--hc-workers",
+        type=int,
+        env_var="HC_WORKERS",
+        default=40,
+        help="Concurrent ConvoyWorker users (pop/submit settlement pressure).",
+    )
+    group.add_argument(
+        "--hc-status-pollers",
+        type=int,
+        env_var="HC_STATUS_POLLERS",
+        default=12,
+        help="Concurrent StatusCheckPoller users (client-backend + micro-cache reads).",
+    )
+    group.add_argument(
+        "--hc-kudos-users",
+        type=int,
+        env_var="HC_KUDOS_USERS",
+        default=2,
+        help="Concurrent KudosTransfer users (fixed pair of registered accounts).",
+    )
+    group.add_argument(
+        "--hc-heavy-api-keys",
+        type=str,
+        env_var="HC_HEAVY_API_KEYS",
+        default="",
+        help="Comma-separated registered API keys for the heavy proxy requesters and pollers.",
+    )
+    group.add_argument(
+        "--hc-kudos-api-keys",
+        type=str,
+        env_var="HC_KUDOS_API_KEYS",
+        default="",
+        help="Comma-separated registered API keys (ideally two) for the kudos-transfer pair.",
+    )
+    group.add_argument(
+        "--hc-served-models",
+        type=str,
+        env_var="HC_SERVED_MODELS",
+        default="koboldcpp/hc-served",
+        help="Comma-separated model names both ConvoyWorker and the requesters use.",
+    )
+    group.add_argument("--hc-baseline", type=float, env_var="HC_BASELINE", default=60.0, help="Baseline phase duration (seconds).")
+    group.add_argument("--hc-pressure", type=float, env_var="HC_PRESSURE", default=180.0, help="Pressure phase duration (seconds).")
+    group.add_argument("--hc-relief", type=float, env_var="HC_RELIEF", default=60.0, help="Relief phase duration (seconds).")
+    group.add_argument("--hc-gen-time-min", type=float, env_var="HC_GEN_TIME_MIN", default=0.2, help="Min simulated worker gen time (s).")
+    group.add_argument("--hc-gen-time-max", type=float, env_var="HC_GEN_TIME_MAX", default=1.0, help="Max simulated worker gen time (s).")
+    group.add_argument(
+        "--hc-max-length",
+        type=int,
+        env_var="HC_MAX_LENGTH",
+        default=24,
+        help="max_length for requester prompts (kept small so anon kudos suffices).",
+    )
+    group.add_argument(
+        "--hc-max-context-length",
+        type=int,
+        env_var="HC_MAX_CONTEXT_LENGTH",
+        default=1024,
+        help="max_context_length for requester prompts.",
+    )
+    group.add_argument(
+        "--hc-n-baseline",
+        type=int,
+        env_var="HC_N_BASELINE",
+        default=2,
+        help="Generation fan-out (n) per request in the baseline phase.",
+    )
+    group.add_argument(
+        "--hc-n-pressure",
+        type=int,
+        env_var="HC_N_PRESSURE",
+        default=6,
+        help="Generation fan-out (n) per request in the pressure phase.",
+    )
+    group.add_argument(
+        "--hc-heavy-max-pending",
+        type=int,
+        env_var="HC_HEAVY_MAX_PENDING",
+        default=20,
+        help="Max in-flight requests a HeavyProxyRequester holds before it only polls.",
+    )
+
+
+@events.test_start.add_listener
+def _configure_convoy_run(environment, **_kwargs) -> None:
+    opts = environment.parsed_options
+
+    AnonRequester.fixed_count = max(int(opts.hc_anon_requestors), 0)
+    HeavyProxyRequester.fixed_count = max(int(opts.hc_heavy_requestors), 0)
+    ConvoyWorker.fixed_count = max(int(opts.hc_workers), 0)
+    StatusCheckPoller.fixed_count = max(int(opts.hc_status_pollers), 0)
+    KudosTransfer.fixed_count = max(int(opts.hc_kudos_users), 0)
+
+    # Worker-owner keys come from the suite-wide --worker-api-keys handled by
+    # locustsuite.events; the convoy adds its own heavy/kudos key pools.
+    worker_keys = _parse_csv(getattr(opts, "worker_api_keys", "") or "")
+
+    configure_convoy(
+        baseline_s=float(opts.hc_baseline),
+        pressure_s=float(opts.hc_pressure),
+        relief_s=float(opts.hc_relief),
+        served_models=_parse_csv(opts.hc_served_models),
+        heavy_keys=_parse_csv(opts.hc_heavy_api_keys),
+        worker_keys=worker_keys,
+        kudos_keys=_parse_csv(opts.hc_kudos_api_keys),
+        gen_time_min=float(opts.hc_gen_time_min),
+        gen_time_max=float(opts.hc_gen_time_max),
+        max_length=int(opts.hc_max_length),
+        max_context_length=int(opts.hc_max_context_length),
+        n_baseline=int(opts.hc_n_baseline),
+        n_pressure=int(opts.hc_n_pressure),
+        heavy_max_pending=int(opts.hc_heavy_max_pending),
+    )
+
+    # Emit the true test-start instant and phase durations so the offline analyzer
+    # buckets the prober/CSV series against the same boundaries current_phase()
+    # applied during the run, rather than an orchestrator-side approximation.
+    phases_out = os.environ.get("HC_PHASES_OUT")
+    if phases_out:
+        run_start = convoy_state.run_start or time.time()
+        boundaries = {
+            "run_start": run_start,
+            "baseline_s": float(opts.hc_baseline),
+            "pressure_s": float(opts.hc_pressure),
+            "relief_s": float(opts.hc_relief),
+            "baseline_start": run_start,
+            "pressure_start": run_start + float(opts.hc_baseline),
+            "relief_start": run_start + float(opts.hc_baseline) + float(opts.hc_pressure),
+            "relief_end": run_start + float(opts.hc_baseline) + float(opts.hc_pressure) + float(opts.hc_relief),
+        }
+        Path(phases_out).write_text(json.dumps(boundaries, indent=2), encoding="utf-8")

--- a/tests/stress/locustfile_queue_pressure.py
+++ b/tests/stress/locustfile_queue_pressure.py
@@ -99,10 +99,18 @@ def _add_queue_pressure_arguments(parser) -> None:
     group.add_argument("--qp-baseline", type=float, env_var="QP_BASELINE", default=60.0, help="Baseline phase duration (seconds).")
     group.add_argument("--qp-pressure", type=float, env_var="QP_PRESSURE", default=180.0, help="Pressure phase duration (seconds).")
     group.add_argument("--qp-relief", type=float, env_var="QP_RELIEF", default=60.0, help="Relief phase duration (seconds).")
-    group.add_argument("--qp-gen-time-min", type=float, env_var="QP_GEN_TIME_MIN", default=0.5, help="Min simulated worker generation time (s).")
-    group.add_argument("--qp-gen-time-max", type=float, env_var="QP_GEN_TIME_MAX", default=2.5, help="Max simulated worker generation time (s).")
-    group.add_argument("--qp-served-max-length", type=int, env_var="QP_SERVED_MAX_LENGTH", default=32, help="max_length for served/backlog prompts.")
-    group.add_argument("--qp-worker-max-length", type=int, env_var="QP_WORKER_MAX_LENGTH", default=512, help="max_length advertised by ServingWorker pops.")
+    group.add_argument(
+        "--qp-gen-time-min", type=float, env_var="QP_GEN_TIME_MIN", default=0.5, help="Min simulated worker generation time (s)."
+    )
+    group.add_argument(
+        "--qp-gen-time-max", type=float, env_var="QP_GEN_TIME_MAX", default=2.5, help="Max simulated worker generation time (s)."
+    )
+    group.add_argument(
+        "--qp-served-max-length", type=int, env_var="QP_SERVED_MAX_LENGTH", default=32, help="max_length for served/backlog prompts."
+    )
+    group.add_argument(
+        "--qp-worker-max-length", type=int, env_var="QP_WORKER_MAX_LENGTH", default=512, help="max_length advertised by ServingWorker pops."
+    )
     group.add_argument(
         "--qp-worker-max-context-length",
         type=int,

--- a/tests/stress/locustfile_queue_pressure.py
+++ b/tests/stress/locustfile_queue_pressure.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Locust entrypoint for the queue-pressure simulation.
+
+Spawns the three queue-pressure populations (``BacklogRequester``,
+``ServingWorker``, ``ServedRequester``) with fixed per-class counts derived from
+CLI arguments, and configures the shared phase schedule and backlog target at
+test start. It reuses the suite's key-parsing and target-preflight ``test_start``
+handler by importing ``locustsuite.events`` for its side effects; that import
+must precede the configuration handler below so keys are parsed first.
+
+Usage:
+    locust -f tests/stress/locustfile_queue_pressure.py --host http://localhost:7001 \
+        --headless --users 60 --spawn-rate 30 --run-time 300s \
+        --qp-workers 20 --qp-served-requestors 8 --qp-backlog-requestors 24 \
+        --qp-backlog-target 3000 --qp-baseline 60 --qp-pressure 180 --qp-relief 60 \
+        --worker-api-keys K1,K2,... --requestor-api-keys R1,... \
+        --qp-backlog-api-keys B1,B2,... --csv qp --csv-full-history
+"""
+# ruff: noqa: I001
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from locust import events
+
+from locustsuite import events as _suite_events  # noqa: F401
+from locustsuite.helpers import _parse_csv
+from locustsuite.users.queue_pressure import (
+    BacklogRequester,
+    ServedRequester,
+    ServingWorker,
+    configure_queue_pressure,
+    qp_state,
+)
+
+__all__ = ["BacklogRequester", "ServedRequester", "ServingWorker"]
+
+
+@events.init_command_line_parser.add_listener
+def _add_queue_pressure_arguments(parser) -> None:
+    group = parser.add_argument_group("AI Horde Queue Pressure Scenario")
+    group.add_argument("--qp-workers", type=int, env_var="QP_WORKERS", default=20, help="Concurrent ServingWorker users.")
+    group.add_argument(
+        "--qp-served-requestors",
+        type=int,
+        env_var="QP_SERVED_REQUESTORS",
+        default=8,
+        help="Concurrent ServedRequester users (servable workload + status polling).",
+    )
+    group.add_argument(
+        "--qp-backlog-requestors",
+        type=int,
+        env_var="QP_BACKLOG_REQUESTORS",
+        default=24,
+        help="Concurrent BacklogRequester users inflating the unserved backlog.",
+    )
+    group.add_argument(
+        "--qp-backlog-target",
+        type=int,
+        env_var="QP_BACKLOG_TARGET",
+        default=3000,
+        help="Target number of unserved backlog prompts to reach during the pressure phase.",
+    )
+    group.add_argument(
+        "--qp-backlog-api-keys",
+        type=str,
+        env_var="QP_BACKLOG_API_KEYS",
+        default="",
+        help="Comma-separated API keys dedicated to backlog inflation (sized to cover the target at ~28 prompts/key).",
+    )
+    group.add_argument(
+        "--qp-backlog-per-key-cap",
+        type=int,
+        env_var="QP_BACKLOG_PER_KEY_CAP",
+        default=28,
+        help="Max in-flight backlog prompts steered to a single key before it is treated as saturated.",
+    )
+    group.add_argument(
+        "--qp-backlog-models",
+        type=str,
+        env_var="QP_BACKLOG_MODELS",
+        default="qp-backlog-unserved-a,qp-backlog-unserved-b",
+        help="Comma-separated decoy model names that no worker declares (keeps backlog prompts unservable).",
+    )
+    group.add_argument(
+        "--qp-served-models",
+        type=str,
+        env_var="QP_SERVED_MODELS",
+        default="koboldcpp/qp-served",
+        help="Comma-separated model names both ServingWorker and ServedRequester use.",
+    )
+    group.add_argument("--qp-baseline", type=float, env_var="QP_BASELINE", default=60.0, help="Baseline phase duration (seconds).")
+    group.add_argument("--qp-pressure", type=float, env_var="QP_PRESSURE", default=180.0, help="Pressure phase duration (seconds).")
+    group.add_argument("--qp-relief", type=float, env_var="QP_RELIEF", default=60.0, help="Relief phase duration (seconds).")
+    group.add_argument("--qp-gen-time-min", type=float, env_var="QP_GEN_TIME_MIN", default=0.5, help="Min simulated worker generation time (s).")
+    group.add_argument("--qp-gen-time-max", type=float, env_var="QP_GEN_TIME_MAX", default=2.5, help="Max simulated worker generation time (s).")
+    group.add_argument("--qp-served-max-length", type=int, env_var="QP_SERVED_MAX_LENGTH", default=32, help="max_length for served/backlog prompts.")
+    group.add_argument("--qp-worker-max-length", type=int, env_var="QP_WORKER_MAX_LENGTH", default=512, help="max_length advertised by ServingWorker pops.")
+    group.add_argument(
+        "--qp-worker-max-context-length",
+        type=int,
+        env_var="QP_WORKER_MAX_CONTEXT_LENGTH",
+        default=2048,
+        help="max_context_length advertised by ServingWorker pops.",
+    )
+
+
+@events.test_start.add_listener
+def _configure_queue_pressure_run(environment, **_kwargs) -> None:
+    opts = environment.parsed_options
+
+    BacklogRequester.fixed_count = max(int(opts.qp_backlog_requestors), 0)
+    ServingWorker.fixed_count = max(int(opts.qp_workers), 0)
+    ServedRequester.fixed_count = max(int(opts.qp_served_requestors), 0)
+
+    configure_queue_pressure(
+        baseline_s=float(opts.qp_baseline),
+        pressure_s=float(opts.qp_pressure),
+        relief_s=float(opts.qp_relief),
+        backlog_target=int(opts.qp_backlog_target),
+        backlog_models=_parse_csv(opts.qp_backlog_models),
+        backlog_keys=_parse_csv(opts.qp_backlog_api_keys),
+        backlog_per_key_cap=int(opts.qp_backlog_per_key_cap),
+        served_models=_parse_csv(opts.qp_served_models),
+        gen_time_min=float(opts.qp_gen_time_min),
+        gen_time_max=float(opts.qp_gen_time_max),
+        served_max_length=int(opts.qp_served_max_length),
+        worker_max_length=int(opts.qp_worker_max_length),
+        worker_max_context_length=int(opts.qp_worker_max_context_length),
+    )
+
+    # Emit the true test-start instant and phase durations so an offline analyzer
+    # can bucket the prober/CSV series against the same phase boundaries the users
+    # applied, rather than an orchestrator-side approximation of when spawning began.
+    phases_out = os.environ.get("QP_PHASES_OUT")
+    if phases_out:
+        # Use the users' own run_start so the analyzer's phase boundaries match
+        # exactly what current_phase() applied during the run.
+        run_start = qp_state.run_start or time.time()
+        boundaries = {
+            "run_start": run_start,
+            "baseline_s": float(opts.qp_baseline),
+            "pressure_s": float(opts.qp_pressure),
+            "relief_s": float(opts.qp_relief),
+            "baseline_start": run_start,
+            "pressure_start": run_start + float(opts.qp_baseline),
+            "relief_start": run_start + float(opts.qp_baseline) + float(opts.qp_pressure),
+            "relief_end": run_start + float(opts.qp_baseline) + float(opts.qp_pressure) + float(opts.qp_relief),
+        }
+        Path(phases_out).write_text(json.dumps(boundaries, indent=2), encoding="utf-8")

--- a/tests/stress/locustsuite/ground_truth.py
+++ b/tests/stress/locustsuite/ground_truth.py
@@ -1,0 +1,357 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Run-scoped ground-truth registry and consistency oracle for the attribution suite.
+
+The attribution workload drives the AI Horde text pipeline through deliberately
+adversarial timings: several simulated workers share a single identity while
+declaring disjoint model lists, and requesters constrain jobs to individual
+models. To decide whether any API response is self-consistent, the checks need a
+single source of truth for what each worker actually declared and when. This
+module holds that source of truth for the lifetime of one Locust process.
+
+Two registries are maintained:
+
+- A declaration timeline mapping each worker name to the ordered list of model
+  declarations it made at pop time. A response that attributes a model to a
+  worker is consistent only if that worker declared the model at some pop.
+- Pair and maintenance slot allocators that let independent Locust greenlets
+  self-organize into the fixed adversarial roles the scenarios require.
+
+The oracle records a violation two ways: it fires a Locust request-event failure
+under a stable, distinctly named pseudo-endpoint so the violation surfaces in the
+standard statistics output, and it appends a structured evidence record to a
+JSONL file so a downstream checker can gate a run and inspect the exact timing
+that produced the inconsistency.
+
+All shared state is guarded by a ``gevent`` lock. Locust greenlets are
+cooperatively scheduled, so contention is only possible across the I/O yield
+points inside these helpers, but the lock keeps the compound read-modify-write
+operations (timeline appends, slot allocation, evidence writes) atomic regardless
+of where a greenlet yields.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import gevent.lock
+
+if TYPE_CHECKING:
+    from locust.env import Environment
+
+
+# ---------------------------------------------------------------------------
+# Naming: model and worker identities are derived deterministically from a slot
+# index so that independent greenlets agree on identities without coordination.
+# ---------------------------------------------------------------------------
+
+_MODEL_NAMESPACE = "attrib"
+
+
+class WorkerRole(StrEnum):
+    """The two members that share a single flapping worker identity.
+
+    Each member declares exactly one model, disjoint from its sibling's, so the
+    shared worker's declared model list flaps between the two as the members
+    interleave their pops.
+    """
+
+    ALPHA = "alpha"
+    BETA = "beta"
+
+
+def pair_role_model(pair_index: int, role: WorkerRole) -> str:
+    """Return the single model a pair member declares for the given role."""
+    return f"{_MODEL_NAMESPACE}/pair{pair_index}-{role.value}"
+
+
+def pair_decoy_model(pair_index: int, decoy_index: int) -> str:
+    """Return a model that no worker ever declares.
+
+    Requesters add these to a job's constraint list so that the recorded model
+    can be checked against the declaration timeline: a response attributing a
+    decoy model to any worker is unambiguously inconsistent, because no worker
+    ever declared it at any pop.
+    """
+    return f"{_MODEL_NAMESPACE}/pair{pair_index}-decoy{decoy_index}"
+
+
+def maintenance_model(slot_index: int) -> str:
+    """Return the unique model served only by one maintenance-flip worker."""
+    return f"{_MODEL_NAMESPACE}/maint{slot_index}"
+
+
+# ---------------------------------------------------------------------------
+# Declaration timeline
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModelDeclaration:
+    """A single pop-time declaration of a worker's model list."""
+
+    wall_time: float
+    models: tuple[str, ...]
+
+
+class DeclarationRegistry:
+    """Records, per worker name, the timeline of model lists declared at pop."""
+
+    def __init__(self) -> None:
+        self._timelines: dict[str, list[ModelDeclaration]] = {}
+        self._lock = gevent.lock.RLock()
+
+    def record(self, worker_name: str, models: tuple[str, ...], wall_time: float | None = None) -> None:
+        """Append a declaration for ``worker_name`` made at ``wall_time``."""
+        entry = ModelDeclaration(wall_time=wall_time if wall_time is not None else time.time(), models=models)
+        with self._lock:
+            self._timelines.setdefault(worker_name, []).append(entry)
+
+    def worker_declared_model(self, worker_name: str, model: str) -> bool:
+        """Return whether ``worker_name`` ever declared ``model`` at any pop."""
+        with self._lock:
+            timeline = self._timelines.get(worker_name)
+            if not timeline:
+                return False
+            return any(model in entry.models for entry in timeline)
+
+    def timeline_as_json(self, worker_name: str) -> list[list[object]]:
+        """Return the worker's declaration timeline as JSON-serializable rows."""
+        with self._lock:
+            timeline = self._timelines.get(worker_name, [])
+            return [[entry.wall_time, list(entry.models)] for entry in timeline]
+
+
+declaration_registry = DeclarationRegistry()
+
+
+# ---------------------------------------------------------------------------
+# Pair coordination: the two members of a pair share one PairState instance so
+# they agree on the current worker name and owning API key even as the identity
+# churns. Only the ALPHA member advances the churn; BETA follows.
+# ---------------------------------------------------------------------------
+
+
+class PairState:
+    """Shared, mutable identity for the two members of a flapping worker pair.
+
+    The pair's models are fixed for the whole run so requesters can target them
+    stably. The worker *name* and owning key advance on churn to exercise the
+    fresh-worker first-pop path (an empty model cache). Untrusted users are
+    capped at three distinct workers, so churn rotates through the pair's
+    assigned keys; when the cap is nonetheless reached the pair freezes on its
+    last-created identity rather than failing.
+    """
+
+    def __init__(self, pair_index: int, api_keys: list[str]) -> None:
+        self._pair_index = pair_index
+        self._api_keys = api_keys
+        self._generation = 0
+        self._frozen = False
+        self._last_churn_at = time.time()
+        self._lock = gevent.lock.RLock()
+
+    @property
+    def pair_index(self) -> int:
+        return self._pair_index
+
+    def current_name(self) -> str:
+        with self._lock:
+            return f"AttribFlapPair{self._pair_index}-g{self._generation}"
+
+    def current_key(self) -> str:
+        with self._lock:
+            return self._api_keys[self._generation % len(self._api_keys)]
+
+    def maybe_churn(self, churn_period: float) -> None:
+        """Advance to a fresh worker identity if the churn period has elapsed.
+
+        A churn period of zero (or a frozen pair) disables churn entirely.
+        """
+        if churn_period <= 0:
+            return
+        with self._lock:
+            if self._frozen:
+                return
+            if (time.time() - self._last_churn_at) < churn_period:
+                return
+            self._generation += 1
+            self._last_churn_at = time.time()
+
+    def rollback_and_freeze(self) -> None:
+        """Revert to the previous identity and stop churning.
+
+        Called when creating a fresh identity was rejected (for example the
+        untrusted three-worker cap). The previous generation's worker already
+        exists, so the pair keeps operating on it.
+        """
+        with self._lock:
+            if self._generation > 0:
+                self._generation -= 1
+            self._frozen = True
+
+
+# ---------------------------------------------------------------------------
+# Slot allocators: hand out deterministic, monotonically increasing indices so
+# that a spawning greenlet knows which pair and role it belongs to.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SlotAllocators:
+    flapping_worker_seq: int = 0
+    attribution_requester_seq: int = 0
+    maintenance_worker_seq: int = 0
+    maintenance_requester_seq: int = 0
+    pair_states: dict[int, PairState] = field(default_factory=dict)
+    lock: gevent.lock.RLock = field(default_factory=gevent.lock.RLock)
+
+
+_allocators = _SlotAllocators()
+
+
+def reset_run_state() -> None:
+    """Clear all run-scoped registries and counters for a fresh test run."""
+    global _allocators
+    _allocators = _SlotAllocators()
+    declaration_registry._timelines.clear()  # noqa: SLF001 - deliberate run reset
+
+
+@dataclass(frozen=True)
+class FlappingAssignment:
+    """The identity a single ``PairedFlappingWorker`` greenlet should assume."""
+
+    pair_index: int
+    role: WorkerRole
+    pair_state: PairState
+
+
+def allocate_flapping_worker(pair_key_pool: list[str], keys_per_pair: int) -> FlappingAssignment:
+    """Assign the next flapping-worker greenlet to a pair and role.
+
+    Consecutive greenlets fill ``(pair, ALPHA)`` then ``(pair, BETA)`` before
+    advancing to the next pair, so every pair gets exactly its two members. Each
+    pair is granted a disjoint slice of the worker key pool for churn rotation.
+    """
+    with _allocators.lock:
+        seq = _allocators.flapping_worker_seq
+        _allocators.flapping_worker_seq += 1
+        pair_index = seq // 2
+        role = WorkerRole.ALPHA if (seq % 2 == 0) else WorkerRole.BETA
+        pair_state = _allocators.pair_states.get(pair_index)
+        if pair_state is None:
+            keys = _slice_keys(pair_key_pool, pair_index, keys_per_pair)
+            pair_state = PairState(pair_index=pair_index, api_keys=keys)
+            _allocators.pair_states[pair_index] = pair_state
+        return FlappingAssignment(pair_index=pair_index, role=role, pair_state=pair_state)
+
+
+def allocate_attribution_requester(pair_count: int) -> int:
+    """Assign the next requester greenlet to a target pair index (round-robin)."""
+    with _allocators.lock:
+        seq = _allocators.attribution_requester_seq
+        _allocators.attribution_requester_seq += 1
+    return seq % max(pair_count, 1)
+
+
+def allocate_maintenance_worker() -> int:
+    """Assign the next maintenance-worker greenlet a unique slot index."""
+    with _allocators.lock:
+        slot = _allocators.maintenance_worker_seq
+        _allocators.maintenance_worker_seq += 1
+    return slot
+
+
+def allocate_maintenance_requester() -> int:
+    """Assign the next maintenance-requester greenlet a slot index."""
+    with _allocators.lock:
+        slot = _allocators.maintenance_requester_seq
+        _allocators.maintenance_requester_seq += 1
+    return slot
+
+
+def _slice_keys(pool: list[str], pair_index: int, keys_per_pair: int) -> list[str]:
+    """Return a stable, non-empty slice of ``pool`` for the given pair.
+
+    Falls back to the whole pool when it is too small to give each pair a
+    disjoint slice, so the harness still runs (churn simply reuses keys).
+    """
+    if not pool:
+        return [""]
+    if keys_per_pair <= 0:
+        return [pool[pair_index % len(pool)]]
+    start = (pair_index * keys_per_pair) % len(pool)
+    keys = [pool[(start + offset) % len(pool)] for offset in range(min(keys_per_pair, len(pool)))]
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# Oracle: violation recording
+# ---------------------------------------------------------------------------
+
+
+class OracleName(StrEnum):
+    """Stable request-event names under which oracle violations are reported."""
+
+    ATTRIBUTION = "oracle:attribution"
+    POSSIBLE_CONTRADICTION = "oracle:possible_contradiction"
+
+
+_ORACLE_REQUEST_TYPE = "ORACLE"
+
+
+class OracleRecorder:
+    """Records oracle violations to Locust statistics and a JSONL evidence file."""
+
+    def __init__(self) -> None:
+        self._evidence_path: Path | None = None
+        self._lock = gevent.lock.RLock()
+
+    def configure(self, evidence_path: str | None) -> None:
+        """Set the JSONL evidence path and truncate any prior file at that path."""
+        with self._lock:
+            if not evidence_path:
+                self._evidence_path = None
+                return
+            self._evidence_path = Path(evidence_path)
+            self._evidence_path.parent.mkdir(parents=True, exist_ok=True)
+            # Truncate so each run's evidence stands alone and the checker never
+            # counts violations carried over from an earlier run.
+            self._evidence_path.write_text("", encoding="utf-8")
+
+    def record(
+        self,
+        environment: Environment,
+        oracle: OracleName,
+        detail: str,
+        evidence: dict[str, object],
+    ) -> None:
+        """Fire a Locust failure for ``oracle`` and append an evidence record."""
+        environment.events.request.fire(
+            request_type=_ORACLE_REQUEST_TYPE,
+            name=str(oracle),
+            response_time=0.0,
+            response_length=0,
+            exception=OracleViolation(f"{oracle}: {detail}"),
+            context={},
+        )
+        record = {"oracle": str(oracle), "wall_time": time.time(), "detail": detail, **evidence}
+        with self._lock:
+            if self._evidence_path is None:
+                return
+            with self._evidence_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+class OracleViolation(Exception):
+    """Raised as the exception payload of an oracle failure request event."""
+
+
+oracle_recorder = OracleRecorder()

--- a/tests/stress/locustsuite/users/attribution.py
+++ b/tests/stress/locustsuite/users/attribution.py
@@ -1,0 +1,629 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Adversarial-timing text workloads for the attribution and possibility oracles.
+
+These Locust users drive the AI Horde text pipeline into two consistency
+scenarios and check every response against the run-scoped ground truth in
+``locustsuite.ground_truth``:
+
+- A flapping-identity scenario in which two workers share one identity and one
+  API key while declaring disjoint single-model lists, interleaving their pops so
+  the shared worker's declared model list alternates rapidly. Requesters then
+  constrain jobs to one real model of the pair alongside decoy models that no
+  worker declares. The oracle asserts that every model a status response
+  attributes to a worker was declared by that worker at some pop, and that it was
+  one the requester asked for.
+- A maintenance-flip scenario in which a worker pops a job, immediately enters
+  maintenance while holding that job in flight, and only later submits it. Its
+  paired requester asserts that a request with an in-flight generation is never
+  reported as impossible.
+
+The workloads are intended to be run with fixed per-class user counts pinned by
+the entrypoint's ``test_start`` handler (see ``locustfile_attribution.py``). Their
+nominal ``weight`` is only a placeholder that keeps Locust from pruning the class
+before those fixed counts are applied.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+import uuid
+
+from locust import HttpUser, between, tag, task
+from locust.exception import RescheduleTask
+
+from ..config import _EXPECTED_RC_RECOVER, _config
+from ..ground_truth import (
+    OracleName,
+    WorkerRole,
+    allocate_attribution_requester,
+    allocate_flapping_worker,
+    allocate_maintenance_requester,
+    allocate_maintenance_worker,
+    declaration_registry,
+    maintenance_model,
+    oracle_recorder,
+    pair_decoy_model,
+    pair_role_model,
+)
+from ..helpers import (
+    _headers,
+    _is_expected_rc,
+    _is_too_many_workers,
+    _pick_requestor_key,
+    _record_expected,
+    _safe_json,
+)
+
+# Each pair is granted a small slice of the worker key pool so churn can rotate
+# through distinct owning accounts. Untrusted users are capped at three distinct
+# workers, which bounds how many fresh identities one key can host.
+_KEYS_PER_PAIR = 3
+
+# A modest in-flight cap keeps each requester cycling jobs quickly rather than
+# building a deep queue, so the adversarial pop/declare interleavings recur often.
+_MAX_PENDING = 3
+
+_TEXT_BRIDGE_AGENT = "KoboldAI Client:1.19.2-stress:https://github.com/koboldai/koboldai-client"
+
+
+def _maintenance_worker_key(slot_index: int) -> str:
+    """Return a worker key for a maintenance slot, taken from the pool's end.
+
+    Maintenance workers own a dedicated worker each and must PUT their own
+    maintenance state, so they draw keys from the opposite end of the pool from
+    the flapping pairs to avoid two adversarial workers sharing one untrusted
+    account (which would compete for that account's three-worker cap).
+    """
+    pool = _config.get("worker_api_keys", [])
+    if not pool:
+        return _config.get("anonymous_api_key", "0000000000")
+    return pool[-(1 + (slot_index % len(pool)))]
+
+
+class PairedFlappingWorker(HttpUser):
+    """One member of a two-member worker pair that shares a single identity.
+
+    Both members pop under the same worker name and owning key, each declaring a
+    single model disjoint from its sibling's, so the shared worker's declared
+    model list flaps between the two as the members interleave their pops. The
+    declaration is recorded in the ground-truth timeline immediately before each
+    pop request fires. A placeholder generation is submitted for any job popped so
+    requester jobs complete quickly and the interleaving recurs at high cadence.
+
+    The ALPHA member periodically churns the pair onto a fresh worker identity to
+    exercise the first-pop path of a worker whose model cache is still empty.
+    """
+
+    # Kept > 0 so Locust does not prune the class before the entrypoint's
+    # test_start handler pins the exact per-class fixed_count.
+    weight = 1
+    fixed_count = 0
+    wait_time = between(0.05, 0.35)
+
+    def on_start(self) -> None:
+        pool = _config.get("worker_api_keys", [])
+        self.assignment = allocate_flapping_worker(pool, keys_per_pair=_KEYS_PER_PAIR)
+        self.model = pair_role_model(self.assignment.pair_index, self.assignment.role)
+        # Only one member drives churn so the shared generation counter advances
+        # once per period rather than once per member.
+        self.drives_churn = self.assignment.role is WorkerRole.ALPHA
+
+    @tag("attribution", "worker")
+    @task
+    def pop_and_submit(self) -> None:
+        opts = self.environment.parsed_options
+        state = self.assignment.pair_state
+        if self.drives_churn:
+            state.maybe_churn(opts.attribution_churn_period)
+        worker_name = state.current_name()
+        api_key = state.current_key()
+        # Record before the pop fires so the timeline never lags the server's
+        # view of what this worker declared for this pop.
+        declaration_registry.record(worker_name, (self.model,))
+        pop_payload = {
+            "name": worker_name,
+            "models": [self.model],
+            "bridge_agent": _TEXT_BRIDGE_AGENT,
+            "nsfw": True,
+            "max_length": 80,
+            "max_context_length": 1024,
+            "softprompts": [],
+            "threads": 1,
+        }
+        job_id = self._pop(api_key, pop_payload, state)
+        if job_id is None:
+            return
+        self._submit_placeholder(api_key, job_id)
+
+    def _pop(self, api_key: str, pop_payload: dict[str, object], state: object) -> str | None:
+        with self.client.post(
+            "/api/v2/generate/text/pop",
+            json=pop_payload,
+            headers=_headers(api_key),
+            catch_response=True,
+            name="/api/v2/generate/text/pop [attribution]",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                data = body or {}
+                return data.get("id")
+            if resp.status_code in (400, 403) and (_is_expected_rc(body, _EXPECTED_RC_RECOVER) or _is_too_many_workers(body)):
+                resp.success()
+                _record_expected(
+                    self.environment,
+                    "POST",
+                    "/api/v2/generate/text/pop [attribution]",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
+                )
+                # The untrusted three-worker cap means a fresh churn identity was
+                # rejected: fall back to the pair's last existing identity.
+                if _is_too_many_workers(body):
+                    state.rollback_and_freeze()  # type: ignore[attr-defined]
+                raise RescheduleTask()
+            if resp.status_code == 429:
+                resp.success()
+                _record_expected(
+                    self.environment,
+                    "POST",
+                    "/api/v2/generate/text/pop [attribution]",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
+                )
+                raise RescheduleTask()
+            resp.failure(f"Text pop failed: {resp.status_code}: {resp.text[:200]}")
+            return None
+
+    def _submit_placeholder(self, api_key: str, job_id: str) -> None:
+        # Submit promptly so the requester's job completes and the flapping race
+        # recurs; the attribution defect lives in the server-side pop-to-procgen
+        # window, not in client submit timing.
+        time.sleep(random.uniform(0.0, 0.1))
+        submit_payload = {
+            "id": job_id,
+            "generation": "Placeholder generation produced by the attribution stress scenario.",
+            "state": "ok",
+            "seed": random.randint(0, 999999999),
+        }
+        with self.client.post(
+            "/api/v2/generate/text/submit",
+            json=submit_payload,
+            headers=_headers(api_key),
+            catch_response=True,
+            name="/api/v2/generate/text/submit [attribution]",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok or resp.status_code == 404 or _is_expected_rc(body, {"InvalidJobID", "InvalidProcGen"}):
+                resp.success()
+                return
+            if resp.status_code == 429:
+                resp.success()
+                return
+            resp.failure(f"Text submit failed: {resp.status_code}: {resp.text[:200]}")
+
+
+class AttributionRequester(HttpUser):
+    """Submits single-model text jobs and checks the reported worker/model pairing.
+
+    Each request constrains generation to exactly one real model of a target pair
+    plus a configurable number of decoy models that no worker ever declares. The
+    request therefore names a model set whose only servable member is the pair's
+    real model, so a well-behaved server records that real model. On completion
+    the requester checks every generation in the final status against the
+    ground-truth declaration timeline.
+    """
+
+    # Kept > 0 so Locust does not prune the class before the entrypoint's
+    # test_start handler pins the exact per-class fixed_count.
+    weight = 1
+    fixed_count = 0
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self) -> None:
+        opts = self.environment.parsed_options
+        self.api_key = _pick_requestor_key()
+        self.pair_index = allocate_attribution_requester(opts.attribution_pairs)
+        # Alternate which member's model is targeted so both declarations of the
+        # shared identity are exercised as the constraint.
+        role = random.choice(list(WorkerRole))
+        real_model = pair_role_model(self.pair_index, role)
+        decoys = [pair_decoy_model(self.pair_index, decoy_index) for decoy_index in range(int(opts.attribution_decoys))]
+        self.requested_models = [real_model, *decoys]
+        self.requested_model_set = set(self.requested_models)
+        self.pending_ids: list[str] = []
+
+    @tag("attribution", "requestor")
+    @task(3)
+    def submit(self) -> None:
+        if len(self.pending_ids) >= _MAX_PENDING:
+            return
+        opts = self.environment.parsed_options
+        payload = {
+            "prompt": "attribution probe " + uuid.uuid4().hex[:10],
+            "params": {
+                "max_length": int(opts.attribution_max_length),
+                "max_context_length": 512,
+                "temperature": 0.7,
+                "top_p": 0.9,
+                "n": 1,
+            },
+            "models": self.requested_models,
+            "trusted_workers": False,
+        }
+        with self.client.post(
+            "/api/v2/generate/text/async",
+            json=payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="/api/v2/generate/text/async [attribution]",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                req_id = (body or {}).get("id")
+                if req_id:
+                    self.pending_ids.append(req_id)
+                return
+            if resp.status_code == 429 or _is_expected_rc(body, {"KudosUpfront", "SharedKeyInsufficientKudos"}):
+                resp.success()
+                _record_expected(
+                    self.environment,
+                    "POST",
+                    "/api/v2/generate/text/async [attribution]",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
+                )
+                raise RescheduleTask()
+            resp.failure(f"Text async failed: {resp.status_code}: {resp.text[:200]}")
+
+    @tag("attribution", "requestor")
+    @task(6)
+    def poll(self) -> None:
+        if not self.pending_ids:
+            return
+        req_id = random.choice(self.pending_ids)
+        with self.client.get(
+            f"/api/v2/generate/text/status/{req_id}",
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="/api/v2/generate/text/status/[id] [attribution]",
+        ) as resp:
+            if resp.ok:
+                data = _safe_json(resp) or {}
+                resp.success()
+                if data.get("done") or data.get("faulted"):
+                    self._check_generations(req_id, data)
+                    if req_id in self.pending_ids:
+                        self.pending_ids.remove(req_id)
+            elif resp.status_code in (404, 410):
+                if req_id in self.pending_ids:
+                    self.pending_ids.remove(req_id)
+                resp.success()
+            elif resp.status_code == 429:
+                resp.success()
+                _record_expected(
+                    self.environment,
+                    "GET",
+                    "/api/v2/generate/text/status/[id] [attribution]",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
+                )
+            else:
+                resp.failure(f"Status {resp.status_code}: {resp.text[:200]}")
+
+    def _check_generations(self, req_id: str, data: dict[str, object]) -> None:
+        generations = data.get("generations") or []
+        if not isinstance(generations, list):
+            return
+        for generation in generations:
+            if not isinstance(generation, dict):
+                continue
+            worker_name = generation.get("worker_name")
+            reported_model = generation.get("model")
+            worker_id = generation.get("worker_id")
+            if not worker_name or not reported_model:
+                # An empty recorded model is a deliberate post-fix outcome (record
+                # no model rather than a wrong one) and is not an attribution
+                # contradiction, so it is not treated as a violation.
+                continue
+            declared = declaration_registry.worker_declared_model(worker_name, reported_model)
+            asked = reported_model in self.requested_model_set
+            if declared and asked:
+                continue
+            if not declared:
+                detail = f"worker '{worker_name}' reported model '{reported_model}' it never declared at any pop"
+            else:
+                detail = f"reported model '{reported_model}' was not among the requested models {self.requested_models}"
+            oracle_recorder.record(
+                self.environment,
+                OracleName.ATTRIBUTION,
+                detail,
+                {
+                    "request_id": req_id,
+                    "generation_id": None,
+                    "worker_id": worker_id,
+                    "worker_name": worker_name,
+                    "reported_model": reported_model,
+                    "requested_models": self.requested_models,
+                    "reported_model_declared": declared,
+                    "reported_model_requested": asked,
+                    "declared_timeline": declaration_registry.timeline_as_json(worker_name),
+                },
+            )
+
+
+class MaintenanceFlipWorker(HttpUser):
+    """A worker that pops a job, enters maintenance holding it, then releases it.
+
+    Each cycle pops one job for its unique model, immediately puts itself into
+    maintenance while keeping that generation in flight, holds for a bounded
+    window, then exits maintenance and submits. While it is in maintenance it is
+    the only worker able to serve its model, so a request with the in-flight
+    generation has no currently-eligible worker: the condition under which a
+    consistent server must still report the request as possible.
+    """
+
+    # Kept > 0 so Locust does not prune the class before the entrypoint's
+    # test_start handler pins the exact per-class fixed_count.
+    weight = 1
+    fixed_count = 0
+    wait_time = between(0.2, 0.6)
+
+    def on_start(self) -> None:
+        self.slot = allocate_maintenance_worker()
+        self.model = maintenance_model(self.slot)
+        self.api_key = _maintenance_worker_key(self.slot)
+        self.worker_name = f"AttribMaint{self.slot}"
+        self.worker_id: str | None = None
+        self.cycles_done = 0
+
+    @tag("attribution", "maintenance", "worker")
+    @task
+    def cycle(self) -> None:
+        opts = self.environment.parsed_options
+        cycle_cap = int(opts.maintenance_cycles)
+        if cycle_cap > 0 and self.cycles_done >= cycle_cap:
+            # This worker has completed its assigned cycles; idle so the request
+            # side can still observe its final released state.
+            time.sleep(1.0)
+            return
+        job_id = self._pop()
+        if job_id is None:
+            return
+        if not self._ensure_worker_id():
+            # Without the worker id the maintenance PUT cannot be addressed; submit
+            # the job so it is not stranded, then retry the identity next cycle.
+            self._submit(job_id)
+            return
+        if not self._set_maintenance(True):
+            self._submit(job_id)
+            return
+        # Hold the popped job in flight while impossible-to-serve from any other
+        # worker, giving the requester a window to observe processing > 0.
+        time.sleep(random.uniform(float(opts.maintenance_hold_min), float(opts.maintenance_hold_max)))
+        self._set_maintenance(False)
+        self._submit(job_id)
+        self.cycles_done += 1
+
+    def _pop(self) -> str | None:
+        pop_payload = {
+            "name": self.worker_name,
+            "models": [self.model],
+            "bridge_agent": _TEXT_BRIDGE_AGENT,
+            "nsfw": True,
+            "max_length": 80,
+            "max_context_length": 1024,
+            "softprompts": [],
+            "threads": 1,
+        }
+        with self.client.post(
+            "/api/v2/generate/text/pop",
+            json=pop_payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="/api/v2/generate/text/pop [maintenance]",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                return (body or {}).get("id")
+            if resp.status_code in (400, 403) and (_is_expected_rc(body, _EXPECTED_RC_RECOVER) or _is_too_many_workers(body)):
+                resp.success()
+                _record_expected(
+                    self.environment,
+                    "POST",
+                    "/api/v2/generate/text/pop [maintenance]",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
+                )
+                raise RescheduleTask()
+            if resp.status_code == 429:
+                resp.success()
+                raise RescheduleTask()
+            resp.failure(f"Maintenance pop failed: {resp.status_code}: {resp.text[:200]}")
+            return None
+
+    def _ensure_worker_id(self) -> bool:
+        if self.worker_id is not None:
+            return True
+        with self.client.get(
+            f"/api/v2/workers/name/{self.worker_name}",
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="/api/v2/workers/name/[name] [maintenance]",
+        ) as resp:
+            if resp.ok:
+                resp.success()
+                data = _safe_json(resp) or {}
+                self.worker_id = data.get("id") if isinstance(data, dict) else None
+                return self.worker_id is not None
+            if resp.status_code == 404:
+                resp.success()
+                return False
+            resp.failure(f"Worker lookup failed: {resp.status_code}: {resp.text[:200]}")
+            return False
+
+    def _set_maintenance(self, enabled: bool) -> bool:
+        with self.client.put(
+            f"/api/v2/workers/{self.worker_id}",
+            json={"maintenance": enabled, "maintenance_msg": "attribution maintenance-flip scenario"},
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="/api/v2/workers/[id] [maintenance-flip]",
+        ) as resp:
+            if resp.ok:
+                resp.success()
+                return True
+            if resp.status_code == 429:
+                resp.success()
+                _record_expected(
+                    self.environment,
+                    "PUT",
+                    "/api/v2/workers/[id] [maintenance-flip]",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
+                )
+                return False
+            resp.failure(f"Maintenance toggle failed: {resp.status_code}: {resp.text[:200]}")
+            return False
+
+    def _submit(self, job_id: str) -> None:
+        submit_payload = {
+            "id": job_id,
+            "generation": "Maintenance-flip scenario generation.",
+            "state": "ok",
+            "seed": random.randint(0, 999999999),
+        }
+        with self.client.post(
+            "/api/v2/generate/text/submit",
+            json=submit_payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="/api/v2/generate/text/submit [maintenance]",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok or resp.status_code == 404 or _is_expected_rc(body, {"InvalidJobID", "InvalidProcGen"}):
+                resp.success()
+                return
+            if resp.status_code == 429:
+                resp.success()
+                return
+            resp.failure(f"Maintenance submit failed: {resp.status_code}: {resp.text[:200]}")
+
+
+class MaintenanceFlipRequester(HttpUser):
+    """Requests a maintenance-flip worker's model and checks the possibility flag.
+
+    On every status poll of an outstanding request it asserts the consistency
+    invariant that a request with an in-flight generation is never reported as
+    impossible: a response carrying ``processing > 0`` together with
+    ``is_possible`` false is recorded as a contradiction.
+    """
+
+    # Kept > 0 so Locust does not prune the class before the entrypoint's
+    # test_start handler pins the exact per-class fixed_count.
+    weight = 1
+    fixed_count = 0
+    wait_time = between(0.15, 0.5)
+
+    def on_start(self) -> None:
+        opts = self.environment.parsed_options
+        self.slot = allocate_maintenance_requester()
+        worker_count = max(int(opts.maintenance_workers), 1)
+        # Target the model of a maintenance worker slot so requests are servable
+        # only by the worker that flaps in and out of maintenance.
+        self.model = maintenance_model(self.slot % worker_count)
+        self.api_key = _pick_requestor_key()
+        self.pending_ids: list[str] = []
+
+    @tag("attribution", "maintenance", "requestor")
+    @task(3)
+    def submit(self) -> None:
+        if len(self.pending_ids) >= _MAX_PENDING:
+            return
+        payload = {
+            "prompt": "maintenance possibility probe " + uuid.uuid4().hex[:10],
+            "params": {"max_length": 40, "max_context_length": 512, "temperature": 0.7, "top_p": 0.9, "n": 1},
+            "models": [self.model],
+            "trusted_workers": False,
+        }
+        with self.client.post(
+            "/api/v2/generate/text/async",
+            json=payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="/api/v2/generate/text/async [maintenance]",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                req_id = (body or {}).get("id")
+                if req_id:
+                    self.pending_ids.append(req_id)
+                return
+            if resp.status_code == 429 or _is_expected_rc(body, {"KudosUpfront", "SharedKeyInsufficientKudos"}):
+                resp.success()
+                raise RescheduleTask()
+            resp.failure(f"Text async failed: {resp.status_code}: {resp.text[:200]}")
+
+    @tag("attribution", "maintenance", "requestor")
+    @task(6)
+    def poll(self) -> None:
+        if not self.pending_ids:
+            return
+        req_id = random.choice(self.pending_ids)
+        with self.client.get(
+            f"/api/v2/generate/text/status/{req_id}",
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="/api/v2/generate/text/status/[id] [maintenance]",
+        ) as resp:
+            if resp.ok:
+                data = _safe_json(resp) or {}
+                resp.success()
+                self._check_possibility(req_id, data)
+                if data.get("done") or data.get("faulted"):
+                    if req_id in self.pending_ids:
+                        self.pending_ids.remove(req_id)
+            elif resp.status_code in (404, 410):
+                if req_id in self.pending_ids:
+                    self.pending_ids.remove(req_id)
+                resp.success()
+            elif resp.status_code == 429:
+                resp.success()
+                _record_expected(
+                    self.environment,
+                    "GET",
+                    "/api/v2/generate/text/status/[id] [maintenance]",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
+                )
+            else:
+                resp.failure(f"Status {resp.status_code}: {resp.text[:200]}")
+
+    def _check_possibility(self, req_id: str, data: dict[str, object]) -> None:
+        processing = data.get("processing", 0)
+        is_possible = data.get("is_possible", True)
+        if not isinstance(processing, int):
+            return
+        if processing > 0 and is_possible is False:
+            oracle_recorder.record(
+                self.environment,
+                OracleName.POSSIBLE_CONTRADICTION,
+                f"request reported is_possible=false while processing={processing}",
+                {
+                    "request_id": req_id,
+                    "generation_id": None,
+                    "model": self.model,
+                    "processing": processing,
+                    "is_possible": is_possible,
+                    "waiting": data.get("waiting"),
+                    "finished": data.get("finished"),
+                    "done": data.get("done"),
+                },
+            )

--- a/tests/stress/locustsuite/users/hot_user_convoy.py
+++ b/tests/stress/locustsuite/users/hot_user_convoy.py
@@ -1,0 +1,535 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Hot-user lock-convoy simulation users for the text generation pipeline.
+
+This module drives contention onto a small set of hot ``users`` rows so the
+tuple-lock queues and ``FOR NO KEY UPDATE`` waits the production forensics
+implicated can be reproduced and measured against a multi-instance rig. The
+production pathology is a lock convoy on the anon requester row (``users.id = 0``)
+and a few heavy accounts, formed where request activation and generation
+settlement both take a ``FOR NO KEY UPDATE`` on the requester and worker-owner
+rows. The populations below are weighted toward that shape:
+
+- ``AnonRequester`` submits text requests with the shared anonymous API key, so
+  every activation debits ``users.id = 0``. It is the largest population,
+  mirroring the production anon share, and requests are amplified with ``n > 1``
+  so a single activation seeds many generations that each settle back onto the
+  same anon row when a worker submits them.
+- ``HeavyProxyRequester`` carries one registered key each and keeps many requests
+  concurrently in flight, standing in for the service-account "proxy" requesters
+  that concentrate load onto a handful of registered rows.
+- ``ConvoyWorker`` pops and submits the served models continuously. Each submit
+  settles onto both the worker-owner row and the requester row (the dual-row
+  ``FOR NO KEY UPDATE``), providing the write concurrency that turns hot-row
+  reads into a queue.
+- ``StatusCheckPoller`` polls status/check endpoints, riding the edge's client
+  backend and its short micro-cache rather than the worker backend, so read-path
+  degradation can be told apart from worker write degradation.
+- ``KudosTransfer`` moves kudos between two fixed registered accounts at a slow
+  trickle, exercising the solvency-gate read plus dual balance writes.
+
+Every request carries a distinct Locust name (``[hc] async anon`` / ``pop`` /
+``submit`` / ``status`` / ...) so per-endpoint latency can be recovered from the
+CSV history. The run moves through three timed phases: a moderate baseline, a
+pressure phase that maximises concurrent anon activations and settlement bursts,
+and a relief phase during which new work stops so recovery can be observed. Phase
+membership is derived from elapsed wall-clock time against durations set at test
+start.
+"""
+
+from __future__ import annotations
+
+import collections
+import random
+import string
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+
+from locust import HttpUser, constant_pacing, tag, task
+from locust.exception import RescheduleTask
+
+from ..config import _EXPECTED_RC_RECOVER
+from ..helpers import (
+    _headers,
+    _is_expected_rc,
+    _is_too_many_workers,
+    _record_expected,
+    _safe_json,
+)
+
+_ANON_API_KEY = "0000000000"
+# Expected 4xx rcs the requester paths hit under load and hot-row contention;
+# recorded as expected rather than counted as failures so the failure table
+# stays a signal for genuine breakage.
+_EXPECTED_ASYNC_RC = {"TooManyPrompts", "KudosUpfront", "SharedKeyInsufficientKudos", "AnonWidth", "MaxLength"}
+_EXPECTED_SUBMIT_RC = {"InvalidJobID", "InvalidProcGen", "DuplicateGeneration"}
+_EXPECTED_KUDOS_RC = {"KudosValidationError", "KudosTransferToSelf", "InvalidTargetUsername", "NotEnoughKudos"}
+
+
+class Phase(Enum):
+    """The three phases a hot-user convoy run moves through in order."""
+
+    BASELINE = "baseline"
+    PRESSURE = "pressure"
+    RELIEF = "relief"
+
+
+@dataclass
+class _ConvoyState:
+    """Process-wide coordination state shared by every convoy user.
+
+    A single Locust worker process runs all users as cooperative greenlets, so a
+    plain object guarded by a lock coordinates the shared recent-id ring and the
+    kudos-account registry without any cross-process concern.
+    """
+
+    run_start: float = 0.0
+    baseline_s: float = 60.0
+    pressure_s: float = 180.0
+    relief_s: float = 60.0
+
+    served_models: list[str] = field(default_factory=list)
+    heavy_keys: list[str] = field(default_factory=list)
+    worker_keys: list[str] = field(default_factory=list)
+    kudos_keys: list[str] = field(default_factory=list)
+
+    gen_time_min: float = 0.2
+    gen_time_max: float = 1.0
+    max_length: int = 24
+    max_context_length: int = 1024
+    # Generation fan-out per request per phase: a larger ``n`` in the pressure
+    # phase multiplies the settlements that land on the hot requester row from a
+    # single (rate-limited) activation.
+    n_baseline: int = 2
+    n_pressure: int = 6
+    # Ceiling on requests a HeavyProxyRequester keeps in flight before it pauses
+    # creating and only polls, mirroring the untuned 30-concurrent-prompt cap.
+    heavy_max_pending: int = 20
+
+    # Bounded ring of recently created request ids that StatusCheckPoller samples,
+    # so many pollers hit the same status paths and ride the edge micro-cache.
+    recent_ids: collections.deque[str] = field(default_factory=lambda: collections.deque(maxlen=256))
+    # Registry of resolved "name#id" identifiers for the kudos accounts, so the
+    # two KudosTransfer users can address each other once both have started.
+    kudos_usernames: list[str] = field(default_factory=list)
+
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+convoy_state = _ConvoyState()
+
+
+def configure_convoy(
+    *,
+    baseline_s: float,
+    pressure_s: float,
+    relief_s: float,
+    served_models: list[str],
+    heavy_keys: list[str],
+    worker_keys: list[str],
+    kudos_keys: list[str],
+    gen_time_min: float,
+    gen_time_max: float,
+    max_length: int,
+    max_context_length: int,
+    n_baseline: int,
+    n_pressure: int,
+    heavy_max_pending: int,
+) -> None:
+    """Reset and populate the shared state at the start of a run.
+
+    Called once from the locustfile's ``test_start`` handler so the CLI-derived
+    parameters are parsed before any user spawns.
+    """
+    convoy_state.run_start = time.time()
+    convoy_state.baseline_s = baseline_s
+    convoy_state.pressure_s = pressure_s
+    convoy_state.relief_s = relief_s
+    convoy_state.served_models = list(served_models)
+    convoy_state.heavy_keys = list(heavy_keys)
+    convoy_state.worker_keys = list(worker_keys)
+    convoy_state.kudos_keys = list(kudos_keys)
+    convoy_state.gen_time_min = gen_time_min
+    convoy_state.gen_time_max = gen_time_max
+    convoy_state.max_length = max_length
+    convoy_state.max_context_length = max_context_length
+    convoy_state.n_baseline = n_baseline
+    convoy_state.n_pressure = n_pressure
+    convoy_state.heavy_max_pending = heavy_max_pending
+    convoy_state.recent_ids.clear()
+    convoy_state.kudos_usernames = []
+
+
+def current_phase() -> Phase:
+    """Return the phase the run is currently in based on elapsed wall-clock time."""
+    elapsed = time.time() - convoy_state.run_start
+    if elapsed < convoy_state.baseline_s:
+        return Phase.BASELINE
+    if elapsed < convoy_state.baseline_s + convoy_state.pressure_s:
+        return Phase.PRESSURE
+    return Phase.RELIEF
+
+
+def _phase_n() -> int:
+    """Return the generation fan-out for the current phase."""
+    return convoy_state.n_pressure if current_phase() is Phase.PRESSURE else convoy_state.n_baseline
+
+
+def _remember_id(request_id: str) -> None:
+    with convoy_state.lock:
+        convoy_state.recent_ids.append(request_id)
+
+
+def _sample_recent_id() -> str | None:
+    with convoy_state.lock:
+        if not convoy_state.recent_ids:
+            return None
+        return random.choice(convoy_state.recent_ids)
+
+
+def _served_model() -> str:
+    return random.choice(convoy_state.served_models or ["koboldcpp/hc-served"])
+
+
+def _async_payload(n: int) -> dict:
+    """Build a small, valid text async payload the convoy workers can serve."""
+    return {
+        "prompt": "hot user convoy " + uuid.uuid4().hex,
+        "params": {
+            "max_length": convoy_state.max_length,
+            "max_context_length": convoy_state.max_context_length,
+            "n": n,
+        },
+        "models": [_served_model()],
+        "trusted_workers": False,
+        "slow_workers": True,
+    }
+
+
+def _submit_async(user: HttpUser, api_key: str, name: str, remember: bool) -> None:
+    """POST a text async request, folding expected rejections into the stats.
+
+    On success the request id is optionally added to the shared recent-id ring so
+    pollers can reference it. Rate-limit and hot-row rejections are recorded under
+    the ``[expected]`` name rather than failing the run.
+    """
+    with user.client.post(
+        "/api/v2/generate/text/async",
+        json=_async_payload(_phase_n()),
+        headers=_headers(api_key),
+        catch_response=True,
+        name=name,
+    ) as resp:
+        body = _safe_json(resp)
+        if resp.ok:
+            resp.success()
+            request_id = (body or {}).get("id")
+            if request_id and remember:
+                _remember_id(request_id)
+            return
+        if resp.status_code == 429 or (resp.status_code == 400 and _is_expected_rc(body, _EXPECTED_ASYNC_RC)):
+            resp.success()
+            _record_expected(user.environment, "POST", name, resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+            return
+        resp.failure(f"async failed: {resp.status_code}: {resp.text[:200]}")
+
+
+def _poll_status(user: HttpUser, api_key: str, request_id: str, name: str, pending: list[str] | None) -> None:
+    """GET a text status, treating completion and 404/410 as terminal."""
+    with user.client.get(
+        f"/api/v2/generate/text/status/{request_id}",
+        headers=_headers(api_key),
+        catch_response=True,
+        name=name,
+    ) as resp:
+        if resp.ok:
+            data = _safe_json(resp) or {}
+            if (data.get("done") or data.get("faulted")) and pending is not None and request_id in pending:
+                pending.remove(request_id)
+            resp.success()
+            return
+        if resp.status_code in (404, 410):
+            if pending is not None and request_id in pending:
+                pending.remove(request_id)
+            resp.success()
+            return
+        if resp.status_code == 429:
+            resp.success()
+            _record_expected(user.environment, "GET", name, resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+            return
+        resp.failure(f"status failed: {resp.status_code}: {resp.text[:200]}")
+
+
+class AnonRequester(HttpUser):
+    """Submits amplified anonymous text requests that debit ``users.id = 0``.
+
+    The largest population by design. Every activation locks the anon requester
+    row, and the ``n``-amplified generations each settle back onto it when a
+    ConvoyWorker submits, so this class supplies the bulk of the hot-row write
+    pressure. It also polls a shared recent id so the status read path is exercised
+    from the anon identity too.
+    """
+
+    fixed_count = 0  # set via --hc-anon-requestors in the locustfile test_start
+    wait_time = constant_pacing(0.5)
+
+    @tag("hc", "async", "anon")
+    @task(4)
+    def submit_anon(self) -> None:
+        if current_phase() is Phase.RELIEF:
+            return
+        _submit_async(self, _ANON_API_KEY, "[hc] async anon", remember=True)
+
+    @tag("hc", "status", "anon")
+    @task(1)
+    def poll_anon(self) -> None:
+        request_id = _sample_recent_id()
+        if request_id is None:
+            return
+        _poll_status(self, _ANON_API_KEY, request_id, "[hc] status anon", pending=None)
+
+
+class HeavyProxyRequester(HttpUser):
+    """Registered "service account" that keeps many requests concurrently in flight.
+
+    Concentrates load onto a single registered row per key, mirroring the proxy
+    accounts that carry disproportionate concurrency in production. It pauses
+    creating new work once its pending set reaches the cap and only polls, so it
+    holds a steady in-flight population rather than growing without bound.
+    """
+
+    fixed_count = 0  # set via --hc-heavy-requestors in the locustfile test_start
+    wait_time = constant_pacing(0.3)
+
+    def on_start(self) -> None:
+        self.pending_ids: list[str] = []
+        keys = convoy_state.heavy_keys
+        self.api_key = random.choice(keys) if keys else _ANON_API_KEY
+
+    @tag("hc", "async", "heavy")
+    @task(3)
+    def submit_heavy(self) -> None:
+        if current_phase() is Phase.RELIEF or len(self.pending_ids) >= convoy_state.heavy_max_pending:
+            return
+        with self.client.post(
+            "/api/v2/generate/text/async",
+            json=_async_payload(_phase_n()),
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[hc] async heavy",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                request_id = (body or {}).get("id")
+                if request_id:
+                    self.pending_ids.append(request_id)
+                    _remember_id(request_id)
+                return
+            if resp.status_code == 429 or (resp.status_code == 400 and _is_expected_rc(body, _EXPECTED_ASYNC_RC)):
+                resp.success()
+                _record_expected(
+                    self.environment, "POST", "[hc] async heavy", resp.elapsed.total_seconds() * 1000, len(resp.content or b""),
+                )
+                return
+            resp.failure(f"heavy async failed: {resp.status_code}: {resp.text[:200]}")
+
+    @tag("hc", "status", "heavy")
+    @task(2)
+    def poll_heavy(self) -> None:
+        if not self.pending_ids:
+            return
+        request_id = random.choice(self.pending_ids)
+        _poll_status(self, self.api_key, request_id, "[hc] status heavy", pending=self.pending_ids)
+
+
+class ConvoyWorker(HttpUser):
+    """Text worker that continuously pops and submits the served models.
+
+    Each successful submit settles onto both the worker-owner row and the
+    requester row, taking the paired ``FOR NO KEY UPDATE`` the convoy hypothesis
+    targets. A large worker population against anon-owned generations concentrates
+    those settlements onto ``users.id = 0``.
+    """
+
+    fixed_count = 0  # set via --hc-workers in the locustfile test_start
+    wait_time = constant_pacing(0.1)
+
+    def on_start(self) -> None:
+        self.worker_name = f"HCWorker-{''.join(random.choices(string.ascii_lowercase, k=8))}"
+        keys = convoy_state.worker_keys
+        self.api_key = random.choice(keys) if keys else _ANON_API_KEY
+
+    @tag("hc", "pop", "submit", "worker")
+    @task
+    def pop_and_submit(self) -> None:
+        pop_payload = {
+            "name": self.worker_name,
+            "models": convoy_state.served_models or ["koboldcpp/hc-served"],
+            "bridge_agent": "KoboldAI Client:1.19.2-stress:https://github.com/koboldai/koboldai-client",
+            "nsfw": True,
+            "max_length": 512,
+            "max_context_length": 2048,
+            "softprompts": [],
+            "threads": 1,
+        }
+        with self.client.post(
+            "/api/v2/generate/text/pop",
+            json=pop_payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[hc] pop",
+        ) as resp:
+            body = _safe_json(resp)
+            if not resp.ok:
+                if resp.status_code in (400, 403) and (_is_expected_rc(body, _EXPECTED_RC_RECOVER) or _is_too_many_workers(body)):
+                    resp.success()
+                    _record_expected(self.environment, "POST", "[hc] pop", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                    raise RescheduleTask()
+                if resp.status_code == 429:
+                    resp.success()
+                    _record_expected(self.environment, "POST", "[hc] pop", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                    raise RescheduleTask()
+                resp.failure(f"pop failed: {resp.status_code}: {resp.text[:200]}")
+                return
+            data = body or {}
+            job_id = data.get("id")
+            resp.success()
+            if not job_id:
+                return
+
+        time.sleep(random.uniform(convoy_state.gen_time_min, convoy_state.gen_time_max))
+
+        submit_payload = {
+            "id": job_id,
+            "generation": "Once upon a time there was a hot user convoy run that settled a job.",
+            "state": "ok",
+            "seed": random.randint(0, 999999999),
+        }
+        with self.client.post(
+            "/api/v2/generate/text/submit",
+            json=submit_payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[hc] submit",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                return
+            if resp.status_code == 404 or _is_expected_rc(body, _EXPECTED_SUBMIT_RC):
+                resp.success()
+                _record_expected(self.environment, "POST", "[hc] submit", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                return
+            if resp.status_code == 429:
+                resp.success()
+                _record_expected(self.environment, "POST", "[hc] submit", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                return
+            resp.failure(f"submit failed: {resp.status_code}: {resp.text[:200]}")
+
+
+class StatusCheckPoller(HttpUser):
+    """Polls status/check endpoints, riding the edge client backend and micro-cache.
+
+    Half its calls target a shared recent request id (so many pollers converge on
+    the same cacheable status path) and half a cacheable meta endpoint. Its latency
+    is the read-path control series that isolates cache-fronted reads from the
+    hot-row write path.
+    """
+
+    fixed_count = 0  # set via --hc-status-pollers in the locustfile test_start
+    wait_time = constant_pacing(0.5)
+
+    def on_start(self) -> None:
+        keys = convoy_state.heavy_keys
+        self.api_key = random.choice(keys) if keys else _ANON_API_KEY
+
+    @tag("hc", "status", "poller")
+    @task(3)
+    def poll_shared(self) -> None:
+        request_id = _sample_recent_id()
+        if request_id is None:
+            return
+        _poll_status(self, _ANON_API_KEY, request_id, "[hc] status poll", pending=None)
+
+    @tag("hc", "status", "meta")
+    @task(1)
+    def poll_meta(self) -> None:
+        with self.client.get(
+            "/api/v2/status/models?type=text",
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[hc] status models",
+        ) as resp:
+            if resp.ok or resp.status_code == 429:
+                resp.success()
+                return
+            resp.failure(f"status models failed: {resp.status_code}: {resp.text[:200]}")
+
+
+class KudosTransfer(HttpUser):
+    """Transfers kudos between two fixed registered accounts at a slow trickle.
+
+    Each user resolves its own ``name#id`` at start and registers it so the pair
+    can address each other. Every transfer exercises the solvency-gate read plus
+    the dual balance writes, adding a second, distinct hot-row write path alongside
+    generation settlement.
+    """
+
+    fixed_count = 0  # set via --hc-kudos-users in the locustfile test_start
+    wait_time = constant_pacing(1.0)
+
+    def on_start(self) -> None:
+        keys = convoy_state.kudos_keys
+        self.api_key = random.choice(keys) if keys else None
+        self.username: str | None = None
+        if self.api_key is None:
+            return
+        with self.client.get(
+            "/api/v2/find_user",
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[hc] find_user",
+        ) as resp:
+            if resp.ok:
+                self.username = (_safe_json(resp) or {}).get("username")
+                if self.username:
+                    with convoy_state.lock:
+                        if self.username not in convoy_state.kudos_usernames:
+                            convoy_state.kudos_usernames.append(self.username)
+                resp.success()
+            else:
+                resp.failure(f"find_user failed: {resp.status_code}: {resp.text[:200]}")
+
+    @tag("hc", "kudos")
+    @task
+    def transfer(self) -> None:
+        if self.api_key is None or self.username is None:
+            return
+        with convoy_state.lock:
+            targets = [name for name in convoy_state.kudos_usernames if name != self.username]
+        if not targets:
+            return
+        with self.client.post(
+            "/api/v2/kudos/transfer",
+            json={"username": random.choice(targets), "amount": 1},
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[hc] kudos transfer",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                return
+            if resp.status_code == 429 or (resp.status_code == 400 and _is_expected_rc(body, _EXPECTED_KUDOS_RC)):
+                resp.success()
+                _record_expected(
+                    self.environment, "POST", "[hc] kudos transfer", resp.elapsed.total_seconds() * 1000, len(resp.content or b""),
+                )
+                return
+            resp.failure(f"kudos transfer failed: {resp.status_code}: {resp.text[:200]}")

--- a/tests/stress/locustsuite/users/queue_pressure.py
+++ b/tests/stress/locustsuite/users/queue_pressure.py
@@ -163,11 +163,7 @@ def _claim_backlog_key() -> str | None:
     with qp_state.lock:
         if qp_state.backlog_created >= qp_state.backlog_target:
             return None
-        candidates = [
-            key
-            for key in qp_state.backlog_keys
-            if qp_state.backlog_key_inflight.get(key, 0) < qp_state.backlog_per_key_cap
-        ]
+        candidates = [key for key in qp_state.backlog_keys if qp_state.backlog_key_inflight.get(key, 0) < qp_state.backlog_per_key_cap]
         if not candidates:
             return None
         key = min(candidates, key=lambda k: qp_state.backlog_key_inflight.get(k, 0))
@@ -396,7 +392,9 @@ class ServedRequester(HttpUser):
                 return
             if resp.status_code == 429 or (resp.status_code == 400 and _is_expected_rc(body, {"TooManyPrompts", "KudosUpfront"})):
                 resp.success()
-                _record_expected(self.environment, "POST", "[qp] async served", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                _record_expected(
+                    self.environment, "POST", "[qp] async served", resp.elapsed.total_seconds() * 1000, len(resp.content or b"")
+                )
                 return
             resp.failure(f"served async failed: {resp.status_code}: {resp.text[:200]}")
 

--- a/tests/stress/locustsuite/users/queue_pressure.py
+++ b/tests/stress/locustsuite/users/queue_pressure.py
@@ -1,0 +1,429 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Queue-pressure simulation users for the text generation pipeline.
+
+This module models three cooperating populations whose interaction places the
+text waiting-prompt queue under controlled, phase-driven pressure so that the
+lock and session behaviour of the pop/submit/activate paths can be measured:
+
+- ``BacklogRequester`` submits text waiting prompts constrained to models that no
+  worker in the run declares. Such prompts activate (``active = true``) but can
+  never be served, so they accumulate as an ever-growing queued backlog. The
+  10s priority-bump job walks every active ``n > 0`` prompt under
+  ``FOR UPDATE SKIP LOCKED``, and the pop candidate query scans and sorts the
+  whole waiting-prompt set; both therefore scale with this backlog. Inflation is
+  bounded by a target size tracked in shared process state so the backlog is
+  driven to a set depth and then held rather than growing without limit.
+- ``ServingWorker`` runs text workers that declare a common served-model set and
+  continuously pop then submit, providing genuine pop concurrency and the
+  per-candidate ``FOR UPDATE`` page locks whose hold time the hypothesis targets.
+- ``ServedRequester`` submits a modest, servable workload and polls its status.
+  Its read latency is measured separately from worker write latency so that
+  "requester reads degrade" can be told apart from "worker writes degrade".
+
+Every request is given a distinct Locust name (``[qp] pop``/``submit``/
+``async ...``/``status ...``) so per-endpoint latency series can be recovered
+from the Locust CSV history.
+
+The population runs through three timed phases within a single run: a baseline
+with workers serving and only light served traffic, a pressure phase during
+which the backlog is inflated toward the target, and a relief phase during which
+inflation stops so recovery can be observed. Phase membership is derived from the
+run's elapsed wall-clock time against durations configured at test start.
+"""
+
+from __future__ import annotations
+
+import random
+import string
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+
+from locust import HttpUser, constant_pacing, tag, task
+from locust.exception import RescheduleTask
+
+from ..config import _EXPECTED_RC_RECOVER, _config
+from ..helpers import (
+    _headers,
+    _is_expected_rc,
+    _is_too_many_workers,
+    _record_expected,
+    _safe_json,
+)
+
+
+class Phase(Enum):
+    """The three phases a queue-pressure run moves through in order."""
+
+    BASELINE = "baseline"
+    PRESSURE = "pressure"
+    RELIEF = "relief"
+
+
+@dataclass
+class _QueuePressureState:
+    """Process-wide coordination state shared by every queue-pressure user.
+
+    A single Locust worker process runs all users as cooperative greenlets, so a
+    plain object guarded by a lock is sufficient to coordinate the collective
+    backlog target across the ``BacklogRequester`` population without any
+    cross-process concern.
+    """
+
+    run_start: float = 0.0
+    baseline_s: float = 60.0
+    pressure_s: float = 150.0
+    relief_s: float = 60.0
+
+    backlog_target: int = 3000
+    backlog_models: list[str] = field(default_factory=list)
+    backlog_keys: list[str] = field(default_factory=list)
+    # Per-key count of prompts believed to be in flight for that key, used to
+    # steer new prompts toward keys that have not yet hit the per-user concurrency
+    # cap (untuned users default to 30 concurrent waiting prompts).
+    backlog_key_inflight: dict[str, int] = field(default_factory=dict)
+    backlog_per_key_cap: int = 28
+    backlog_created: int = 0
+
+    served_models: list[str] = field(default_factory=list)
+    gen_time_min: float = 0.5
+    gen_time_max: float = 2.5
+    served_max_length: int = 32
+    worker_max_length: int = 512
+    worker_max_context_length: int = 2048
+
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+qp_state = _QueuePressureState()
+
+
+def configure_queue_pressure(
+    *,
+    baseline_s: float,
+    pressure_s: float,
+    relief_s: float,
+    backlog_target: int,
+    backlog_models: list[str],
+    backlog_keys: list[str],
+    backlog_per_key_cap: int,
+    served_models: list[str],
+    gen_time_min: float,
+    gen_time_max: float,
+    served_max_length: int,
+    worker_max_length: int,
+    worker_max_context_length: int,
+) -> None:
+    """Reset and populate the shared state at the start of a run.
+
+    Called once from the locustfile's ``test_start`` handler so the CLI-derived
+    parameters are guaranteed to be parsed before any user spawns.
+    """
+    qp_state.run_start = time.time()
+    qp_state.baseline_s = baseline_s
+    qp_state.pressure_s = pressure_s
+    qp_state.relief_s = relief_s
+    qp_state.backlog_target = backlog_target
+    qp_state.backlog_models = list(backlog_models)
+    qp_state.backlog_keys = list(backlog_keys)
+    qp_state.backlog_key_inflight = {key: 0 for key in backlog_keys}
+    qp_state.backlog_per_key_cap = backlog_per_key_cap
+    qp_state.backlog_created = 0
+    qp_state.served_models = list(served_models)
+    qp_state.gen_time_min = gen_time_min
+    qp_state.gen_time_max = gen_time_max
+    qp_state.served_max_length = served_max_length
+    qp_state.worker_max_length = worker_max_length
+    qp_state.worker_max_context_length = worker_max_context_length
+
+
+def current_phase() -> Phase:
+    """Return the phase the run is currently in based on elapsed wall-clock time."""
+    elapsed = time.time() - qp_state.run_start
+    if elapsed < qp_state.baseline_s:
+        return Phase.BASELINE
+    if elapsed < qp_state.baseline_s + qp_state.pressure_s:
+        return Phase.PRESSURE
+    return Phase.RELIEF
+
+
+def _claim_backlog_key() -> str | None:
+    """Reserve capacity on a backlog key, or ``None`` if the target is reached.
+
+    Returns the chosen key with its in-flight tally pre-incremented so concurrent
+    greenlets do not all pile onto the same key. The reservation is released via
+    ``_release_backlog_key`` when a create attempt fails, keeping the tally an
+    honest proxy for the live backlog (unserved prompts never drain on their own).
+    """
+    with qp_state.lock:
+        if qp_state.backlog_created >= qp_state.backlog_target:
+            return None
+        candidates = [
+            key
+            for key in qp_state.backlog_keys
+            if qp_state.backlog_key_inflight.get(key, 0) < qp_state.backlog_per_key_cap
+        ]
+        if not candidates:
+            return None
+        key = min(candidates, key=lambda k: qp_state.backlog_key_inflight.get(k, 0))
+        qp_state.backlog_key_inflight[key] += 1
+        qp_state.backlog_created += 1
+        return key
+
+
+def _release_backlog_key(key: str, *, mark_full: bool) -> None:
+    """Undo a claim after a failed create; optionally mark the key as saturated."""
+    with qp_state.lock:
+        qp_state.backlog_created = max(0, qp_state.backlog_created - 1)
+        if mark_full:
+            # The user's concurrency cap was hit; park the key at the cap so no
+            # further attempts are steered to it this run.
+            qp_state.backlog_key_inflight[key] = qp_state.backlog_per_key_cap
+        else:
+            qp_state.backlog_key_inflight[key] = max(0, qp_state.backlog_key_inflight.get(key, 1) - 1)
+
+
+class BacklogRequester(HttpUser):
+    """Inflates the queued text backlog with prompts no worker can serve.
+
+    Only submits during the pressure phase and only until the shared backlog
+    target is reached, so the backlog is driven to a controlled depth and then
+    held. Prompts are constrained to decoy models and to a short ``max_length``
+    so they remain valid, activate, and sit in the queue indefinitely without
+    ever matching a serving worker.
+    """
+
+    fixed_count = 0  # set via --qp-backlog-requestors in the locustfile test_start
+    # A tight pacing keeps the inflation rate high without a per-request sleep so
+    # the backlog can reach the thousands within the pressure window.
+    wait_time = constant_pacing(0.2)
+
+    @tag("qp", "async", "backlog")
+    @task
+    def inflate_backlog(self) -> None:
+        if current_phase() is not Phase.PRESSURE:
+            return
+        key = _claim_backlog_key()
+        if key is None:
+            return
+        decoy_models = qp_state.backlog_models or ["qp-backlog-unserved"]
+        payload = {
+            "prompt": "queue pressure backlog " + uuid.uuid4().hex,
+            "params": {
+                "max_length": min(24, qp_state.served_max_length),
+                "max_context_length": 1024,
+                "n": 1,
+            },
+            "models": [random.choice(decoy_models)],
+            "trusted_workers": False,
+            "slow_workers": True,
+        }
+        succeeded = False
+        try:
+            with self.client.post(
+                "/api/v2/generate/text/async",
+                json=payload,
+                headers=_headers(key),
+                catch_response=True,
+                name="[qp] async backlog",
+            ) as resp:
+                body = _safe_json(resp)
+                if resp.ok:
+                    resp.success()
+                    succeeded = True
+                    return
+                if resp.status_code == 429:
+                    resp.success()
+                    _record_expected(
+                        self.environment, "POST", "[qp] async backlog", resp.elapsed.total_seconds() * 1000, len(resp.content or b"")
+                    )
+                    return
+                if resp.status_code == 400 and _is_expected_rc(body, {"TooManyPrompts", "KudosUpfront", "SharedKeyInsufficientKudos"}):
+                    resp.success()
+                    _record_expected(
+                        self.environment, "POST", "[qp] async backlog", resp.elapsed.total_seconds() * 1000, len(resp.content or b"")
+                    )
+                    # A concurrency-cap rejection means this key is saturated.
+                    if _is_expected_rc(body, {"TooManyPrompts"}):
+                        _release_backlog_key(key, mark_full=True)
+                        succeeded = True  # release already handled; skip the generic release below
+                    return
+                resp.failure(f"backlog async failed: {resp.status_code}: {resp.text[:200]}")
+        finally:
+            if not succeeded:
+                _release_backlog_key(key, mark_full=False)
+
+
+class ServingWorker(HttpUser):
+    """Text worker that continuously pops and submits servable jobs.
+
+    Declares the common served-model set, so it competes for the servable subset
+    of the queue while paging past the unserved backlog the pop query must still
+    scan and sort. After a successful pop it waits a short simulated generation
+    time and submits, mirroring a fast real worker's cadence.
+    """
+
+    fixed_count = 0  # set via --qp-workers in the locustfile test_start
+    # Pop promptly; the realistic think time between jobs is the simulated
+    # generation time applied after a successful pop, not a fixed task wait.
+    wait_time = constant_pacing(0.1)
+
+    def on_start(self) -> None:
+        self.worker_name = f"QPWorker-{''.join(random.choices(string.ascii_lowercase, k=6))}"
+        keys = _config.get("worker_api_keys", [])
+        # Each worker owns a stable key for its lifetime so worker identity does
+        # not churn mid-run and confound the pop attribution.
+        self.api_key = random.choice(keys) if keys else _config.get("anonymous_api_key", "0000000000")
+
+    @tag("qp", "pop", "submit", "worker")
+    @task
+    def pop_and_submit(self) -> None:
+        served = qp_state.served_models or ["koboldcpp/qp-served"]
+        pop_payload = {
+            "name": self.worker_name,
+            "models": served,
+            "bridge_agent": "KoboldAI Client:1.19.2-stress:https://github.com/koboldai/koboldai-client",
+            "nsfw": True,
+            "max_length": qp_state.worker_max_length,
+            "max_context_length": qp_state.worker_max_context_length,
+            "softprompts": [],
+            "threads": 1,
+        }
+        with self.client.post(
+            "/api/v2/generate/text/pop",
+            json=pop_payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[qp] pop",
+        ) as resp:
+            body = _safe_json(resp)
+            if not resp.ok:
+                if resp.status_code in (400, 403) and (_is_expected_rc(body, _EXPECTED_RC_RECOVER) or _is_too_many_workers(body)):
+                    resp.success()
+                    _record_expected(self.environment, "POST", "[qp] pop", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                    raise RescheduleTask()
+                if resp.status_code == 429:
+                    resp.success()
+                    _record_expected(self.environment, "POST", "[qp] pop", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                    raise RescheduleTask()
+                resp.failure(f"pop failed: {resp.status_code}: {resp.text[:200]}")
+                return
+            data = body or {}
+            job_id = data.get("id")
+            resp.success()
+            if not job_id:
+                return
+
+        time.sleep(random.uniform(qp_state.gen_time_min, qp_state.gen_time_max))
+
+        submit_payload = {
+            "id": job_id,
+            "generation": "Once upon a time there was a queue pressure run that completed a job.",
+            "state": "ok",
+            "seed": random.randint(0, 999999999),
+        }
+        with self.client.post(
+            "/api/v2/generate/text/submit",
+            json=submit_payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[qp] submit",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                return
+            if resp.status_code == 404 or _is_expected_rc(body, {"InvalidJobID", "InvalidProcGen"}):
+                resp.success()
+                _record_expected(self.environment, "POST", "[qp] submit", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                return
+            if resp.status_code == 429:
+                resp.success()
+                _record_expected(self.environment, "POST", "[qp] submit", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                return
+            resp.failure(f"submit failed: {resp.status_code}: {resp.text[:200]}")
+
+
+class ServedRequester(HttpUser):
+    """Submits a modest servable workload and polls its status.
+
+    Its prompts declare the served-model set so the workers can complete them;
+    its request latency (async create and status read) is the control series that
+    isolates read-path degradation from the worker write path.
+    """
+
+    fixed_count = 0  # set via --qp-served-requestors in the locustfile test_start
+    wait_time = constant_pacing(1.0)
+
+    def on_start(self) -> None:
+        self.pending_ids: list[str] = []
+        keys = _config.get("requestor_api_keys", [])
+        self.api_key = random.choice(keys) if keys else _config.get("anonymous_api_key", "0000000000")
+
+    @tag("qp", "async", "served")
+    @task(2)
+    def submit_served(self) -> None:
+        served = qp_state.served_models or ["koboldcpp/qp-served"]
+        payload = {
+            "prompt": "queue pressure served " + uuid.uuid4().hex[:10],
+            "params": {
+                "max_length": qp_state.served_max_length,
+                "max_context_length": 1024,
+                "n": 1,
+            },
+            "models": [random.choice(served)],
+            "trusted_workers": False,
+            "slow_workers": True,
+        }
+        with self.client.post(
+            "/api/v2/generate/text/async",
+            json=payload,
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[qp] async served",
+        ) as resp:
+            body = _safe_json(resp)
+            if resp.ok:
+                resp.success()
+                req_id = (body or {}).get("id")
+                if req_id:
+                    self.pending_ids.append(req_id)
+                return
+            if resp.status_code == 429 or (resp.status_code == 400 and _is_expected_rc(body, {"TooManyPrompts", "KudosUpfront"})):
+                resp.success()
+                _record_expected(self.environment, "POST", "[qp] async served", resp.elapsed.total_seconds() * 1000, len(resp.content or b""))
+                return
+            resp.failure(f"served async failed: {resp.status_code}: {resp.text[:200]}")
+
+    @tag("qp", "status", "served")
+    @task(3)
+    def poll_served(self) -> None:
+        if not self.pending_ids:
+            return
+        req_id = random.choice(self.pending_ids)
+        with self.client.get(
+            f"/api/v2/generate/text/status/{req_id}",
+            headers=_headers(self.api_key),
+            catch_response=True,
+            name="[qp] status served",
+        ) as resp:
+            if resp.ok:
+                data = _safe_json(resp) or {}
+                if data.get("done") or data.get("faulted"):
+                    self.pending_ids.remove(req_id)
+                resp.success()
+            elif resp.status_code in (404, 410):
+                self.pending_ids.remove(req_id)
+                resp.success()
+            elif resp.status_code == 429:
+                resp.success()
+                _record_expected(
+                    self.environment, "GET", "[qp] status served", resp.elapsed.total_seconds() * 1000, len(resp.content or b"")
+                )
+            else:
+                resp.failure(f"served status failed: {resp.status_code}: {resp.text[:200]}")

--- a/tests/stress/pg_prober.py
+++ b/tests/stress/pg_prober.py
@@ -1,0 +1,348 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Standalone Postgres sampler for the queue-pressure simulation.
+
+Runs as its own process and samples a handful of cheap catalog views once per
+second, appending one timestamped JSON object per sample to a JSONL file. The
+series it captures are the instrumentation used to confirm or refute the
+lock-convoy hypothesis:
+
+- ``pg_stat_activity`` backend counts grouped by ``state`` and by
+  ``wait_event_type``/``wait_event``, plus the active-session total (the metric
+  that spikes as sessions pile up toward the connection limit).
+- ``pg_locks`` counts grouped by ``mode`` with granted and ungranted totals kept
+  separate, so ``RowShareLock`` pressure and any lock waiting are both visible.
+- The ``pg_stat_database`` cumulative ``deadlocks`` counter for the target
+  database, whose per-interval delta reveals deadlocks confined to a window.
+- The current text and image waiting-prompt backlog depth, via a plain
+  ``SELECT count(*)`` over ``waiting_prompts`` filtered to the same
+  ``n > 0 AND active AND NOT faulted`` predicate the priority-bump and pop scans
+  use. This is an MVCC read that takes no row locks, so the probe never
+  perturbs the very contention it measures.
+- Lock counts confined to the ``users`` table (tuple-lock granted/waiting and
+  the total waiting across modes), which localise contention to the hot-user
+  row family.
+- Blocking chains derived from ``pg_blocking_pids``: each blocked/blocker edge
+  with the blocker's session state and transaction age, the blocked and blocker
+  query texts (truncated), and per-chain flags marking the implicated
+  ``SELECT ... FOR NO KEY UPDATE`` on the users table (and the ``users.id = 0``
+  anon row specifically). Summary counters accompany the (bounded) chain list so
+  a run can be judged on chain depth and idle-in-transaction blockers without
+  re-parsing SQL offline.
+
+The sampling connection runs in autocommit with a short ``statement_timeout`` so
+a stalled sample cannot itself pile onto the backend under study. The users-lock
+and blocking-chain probes are folded in as best-effort additions: a failure in
+either is attached to the record and left non-fatal so the base series survive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from types import FrameType
+
+import psycopg2
+
+_APPLICATION_NAME = "qp_prober"
+
+# Backlog predicate mirroring increment_extra_priority / the pop candidate scan
+# (waiting_prompts is single-table-inheritance keyed by wp_type).
+_BACKLOG_SQL = """
+SELECT wp_type, count(*)
+FROM waiting_prompts
+WHERE n > 0 AND active = true AND faulted = false
+GROUP BY wp_type
+"""
+
+_ACTIVITY_STATE_SQL = """
+SELECT coalesce(state, 'unknown') AS state, count(*)
+FROM pg_stat_activity
+WHERE datname = %s AND application_name <> %s AND pid <> pg_backend_pid()
+GROUP BY state
+"""
+
+_ACTIVITY_WAIT_SQL = """
+SELECT coalesce(wait_event_type, 'none') AS wet, coalesce(wait_event, 'none') AS we, count(*)
+FROM pg_stat_activity
+WHERE datname = %s AND application_name <> %s AND pid <> pg_backend_pid() AND state = 'active'
+GROUP BY wait_event_type, wait_event
+"""
+
+_LOCKS_SQL = """
+SELECT mode, granted, count(*)
+FROM pg_locks
+GROUP BY mode, granted
+"""
+
+_DEADLOCKS_SQL = """
+SELECT deadlocks
+FROM pg_stat_database
+WHERE datname = %s
+"""
+
+# Lock counts confined to the ``users`` table, the row family the hot-user
+# convoy targets. Resolving the oid through a scalar sub-select keeps the query
+# safe on a database where the table is absent (the sub-select yields NULL and
+# no rows match) rather than raising an ``undefined_table`` that would abort the
+# whole sample.
+_USERS_LOCKS_SQL = """
+SELECT locktype, granted, count(*)
+FROM pg_locks
+WHERE relation = (SELECT oid FROM pg_class WHERE relname = 'users' LIMIT 1)
+GROUP BY locktype, granted
+"""
+
+# Blocking chains derived from ``pg_blocking_pids``: one row per (blocked pid,
+# blocker pid) edge, carrying the blocker's session state and transaction age so
+# a chain headed by an ``idle in transaction`` session (the observed convoy
+# culprit) can be told apart from one headed by an actively-working backend. The
+# query texts are truncated server-side to bound the JSONL line size.
+_BLOCKING_CHAINS_SQL = """
+SELECT
+    blocked.pid AS blocked_pid,
+    coalesce(blocked.state, '') AS blocked_state,
+    coalesce(blocked.wait_event_type, '') || '/' || coalesce(blocked.wait_event, '') AS blocked_wait,
+    left(coalesce(blocked.query, ''), %s) AS blocked_query,
+    blocker.pid AS blocker_pid,
+    coalesce(blocker.state, '') AS blocker_state,
+    extract(epoch FROM (now() - blocker.xact_start)) AS blocker_xact_age_s,
+    left(coalesce(blocker.query, ''), %s) AS blocker_query
+FROM pg_stat_activity AS blocked
+CROSS JOIN LATERAL unnest(pg_blocking_pids(blocked.pid)) AS bp(blocker_pid)
+JOIN pg_stat_activity AS blocker ON blocker.pid = bp.blocker_pid
+WHERE blocked.datname = %s
+"""
+
+_QUERY_TRUNCATE_CHARS = 300
+_MAX_CHAINS_PER_SAMPLE = 25
+
+# A waiting ``SELECT ... FOR NO KEY UPDATE`` over the users table is the exact
+# statement the production forensics implicated. ``users.id = 0`` is the anon
+# requester row; the literal survives in the query text as ``in (0`` or ``= 0``.
+_FNKU_RE = re.compile(r"for no key update", re.IGNORECASE)
+_USERS_RE = re.compile(r"\busers\b", re.IGNORECASE)
+_USERS_ZERO_RE = re.compile(r"(in \(0[\s,)])|(=\s*0\b)", re.IGNORECASE)
+
+
+class _StopFlag:
+    """Cooperative stop flag toggled by SIGINT/SIGTERM so the file is flushed cleanly."""
+
+    def __init__(self) -> None:
+        self.stop = False
+
+    def request_stop(self, _signum: int, _frame: FrameType | None) -> None:
+        self.stop = True
+
+
+def _connect(args: argparse.Namespace) -> psycopg2.extensions.connection:
+    conn = psycopg2.connect(
+        host=args.host,
+        port=args.port,
+        dbname=args.dbname,
+        user=args.user,
+        password=args.password,
+        application_name=_APPLICATION_NAME,
+        connect_timeout=5,
+    )
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("SET statement_timeout = '3000ms'")
+    return conn
+
+
+def _sample_users_locks(cur: psycopg2.extensions.cursor, record: dict[str, object]) -> None:
+    """Fold per-``users``-table lock counts into ``record`` (best effort).
+
+    A failure here (e.g. a missing table on an unexpected schema) is attached as
+    ``users_lock_error`` and left non-fatal so the base activity/lock series the
+    sample already carries are never lost to a lock-chain probe error.
+    """
+    try:
+        cur.execute(_USERS_LOCKS_SQL)
+    except psycopg2.Error as exc:
+        record["users_lock_error"] = str(exc)
+        return
+    tuple_waiting = 0
+    tuple_granted = 0
+    waiting_total = 0
+    for locktype, granted, count in cur.fetchall():
+        count = int(count)
+        if not granted:
+            waiting_total += count
+        if locktype == "tuple":
+            if granted:
+                tuple_granted += count
+            else:
+                tuple_waiting += count
+    record["users_tuple_lock_waiting"] = tuple_waiting
+    record["users_tuple_lock_granted"] = tuple_granted
+    record["users_lock_waiting_total"] = waiting_total
+
+
+def _sample_blocking_chains(cur: psycopg2.extensions.cursor, dbname: str, record: dict[str, object]) -> None:
+    """Fold ``pg_blocking_pids`` chains and their summary counts into ``record``.
+
+    Each captured chain is classified so the analyzer can isolate the convoy
+    signature without re-parsing SQL: ``for_no_key_update`` marks the implicated
+    statement, ``on_users`` that it touches the users table, and ``users_id_zero``
+    that it references the anon requester row specifically. The chain list is
+    truncated to a bounded count while the summary counters reflect every edge.
+    """
+    try:
+        cur.execute(_BLOCKING_CHAINS_SQL, (_QUERY_TRUNCATE_CHARS, _QUERY_TRUNCATE_CHARS, dbname))
+        rows = cur.fetchall()
+    except psycopg2.Error as exc:
+        record["chain_error"] = str(exc)
+        return
+    chains: list[dict[str, object]] = []
+    idle_blocker_count = 0
+    fnku_waits = 0
+    fnku_users0_waits = 0
+    max_blocker_age = 0.0
+    for blocked_pid, blocked_state, blocked_wait, blocked_query, blocker_pid, blocker_state, blocker_age, blocker_query in rows:
+        age = float(blocker_age) if blocker_age is not None else 0.0
+        max_blocker_age = max(max_blocker_age, age)
+        for_no_key_update = bool(_FNKU_RE.search(blocked_query or ""))
+        on_users = bool(_USERS_RE.search(blocked_query or ""))
+        users_id_zero = for_no_key_update and on_users and bool(_USERS_ZERO_RE.search(blocked_query or ""))
+        blocker_idle = (blocker_state or "").startswith("idle in transaction")
+        if blocker_idle:
+            idle_blocker_count += 1
+        if for_no_key_update and on_users:
+            fnku_waits += 1
+            if users_id_zero:
+                fnku_users0_waits += 1
+        if len(chains) < _MAX_CHAINS_PER_SAMPLE:
+            chains.append(
+                {
+                    "blocked_pid": int(blocked_pid),
+                    "blocked_state": blocked_state,
+                    "blocked_wait": blocked_wait,
+                    "blocked_query": blocked_query,
+                    "blocker_pid": int(blocker_pid),
+                    "blocker_state": blocker_state,
+                    "blocker_xact_age_s": round(age, 3),
+                    "blocker_query": blocker_query,
+                    "for_no_key_update": for_no_key_update,
+                    "on_users": on_users,
+                    "users_id_zero": users_id_zero,
+                    "blocker_idle_in_transaction": blocker_idle,
+                },
+            )
+    record["blocking_chains"] = chains
+    record["blocking_chain_count"] = len(rows)
+    record["blocking_chains_idle_blocker"] = idle_blocker_count
+    record["max_blocker_xact_age_s"] = round(max_blocker_age, 3)
+    record["users_fnku_waits"] = fnku_waits
+    record["users_fnku_id_zero_waits"] = fnku_users0_waits
+
+
+def _sample(conn: psycopg2.extensions.connection, dbname: str) -> dict[str, object]:
+    """Take one sample of the catalog views, returning a JSON-serialisable record."""
+    record: dict[str, object] = {
+        "ts": time.time(),
+        "iso": datetime.now(timezone.utc).isoformat(),
+    }
+    with conn.cursor() as cur:
+        cur.execute(_ACTIVITY_STATE_SQL, (dbname, _APPLICATION_NAME))
+        by_state = {row[0]: int(row[1]) for row in cur.fetchall()}
+        record["activity_by_state"] = by_state
+        record["active_sessions"] = by_state.get("active", 0)
+        record["idle_in_transaction"] = by_state.get("idle in transaction", 0)
+        record["total_sessions"] = sum(by_state.values())
+
+        cur.execute(_ACTIVITY_WAIT_SQL, (dbname, _APPLICATION_NAME))
+        by_wait = {f"{row[0]}/{row[1]}": int(row[2]) for row in cur.fetchall()}
+        record["activity_by_wait"] = by_wait
+        # Lock waits are the wait_event_type most directly implicated by the hypothesis.
+        record["active_lock_waits"] = sum(v for k, v in by_wait.items() if k.startswith("Lock/"))
+
+        cur.execute(_LOCKS_SQL)
+        granted: dict[str, int] = {}
+        waiting: dict[str, int] = {}
+        for mode, is_granted, count in cur.fetchall():
+            target = granted if is_granted else waiting
+            target[mode] = target.get(mode, 0) + int(count)
+        record["locks_granted"] = granted
+        record["locks_waiting"] = waiting
+        record["rowsharelock_granted"] = granted.get("RowShareLock", 0)
+        record["rowsharelock_waiting"] = waiting.get("RowShareLock", 0)
+        record["locks_waiting_total"] = sum(waiting.values())
+
+        cur.execute(_DEADLOCKS_SQL, (dbname,))
+        deadlock_row = cur.fetchone()
+        record["deadlocks"] = int(deadlock_row[0]) if deadlock_row else 0
+
+        cur.execute(_BACKLOG_SQL)
+        backlog = {row[0]: int(row[1]) for row in cur.fetchall()}
+        record["backlog_text"] = backlog.get("text", 0)
+        record["backlog_image"] = backlog.get("image", 0)
+
+        _sample_users_locks(cur, record)
+        _sample_blocking_chains(cur, dbname, record)
+    return record
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Sample the queue-pressure Postgres into JSONL once per second.")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=15432)
+    parser.add_argument("--dbname", default="postgres")
+    parser.add_argument("--user", default="postgres")
+    parser.add_argument("--password", default="postgres")
+    parser.add_argument("--interval", type=float, default=1.0, help="Seconds between samples.")
+    parser.add_argument("--duration", type=float, default=0.0, help="Stop after N seconds (0 runs until signalled).")
+    parser.add_argument("--out", required=True, help="Output JSONL path.")
+    args = parser.parse_args(argv)
+
+    stop_flag = _StopFlag()
+    signal.signal(signal.SIGINT, stop_flag.request_stop)
+    signal.signal(signal.SIGTERM, stop_flag.request_stop)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = _connect(args)
+    deadline = time.time() + args.duration if args.duration > 0 else None
+    samples = 0
+    print(f"[prober] sampling {args.host}:{args.port}/{args.dbname} every {args.interval}s -> {out_path}", flush=True)
+    with out_path.open("a", encoding="utf-8") as handle:
+        while not stop_flag.stop:
+            loop_start = time.time()
+            try:
+                record = _sample(conn, args.dbname)
+            except psycopg2.Error as exc:
+                record = {"ts": time.time(), "iso": datetime.now(timezone.utc).isoformat(), "sample_error": str(exc)}
+                # A dropped/timed-out connection (e.g. across a Postgres restart) is
+                # recovered rather than fatal, since the run tunes and restarts PG.
+                try:
+                    conn.close()
+                except psycopg2.Error:
+                    pass
+                try:
+                    conn = _connect(args)
+                except psycopg2.Error as reconnect_exc:
+                    record["reconnect_error"] = str(reconnect_exc)
+            handle.write(json.dumps(record) + "\n")
+            handle.flush()
+            samples += 1
+            if deadline is not None and time.time() >= deadline:
+                break
+            sleep_for = args.interval - (time.time() - loop_start)
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+    print(f"[prober] wrote {samples} samples to {out_path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/stress/pg_prober.py
+++ b/tests/stress/pg_prober.py
@@ -52,7 +52,7 @@ import re
 import signal
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from types import FrameType
 
@@ -303,7 +303,7 @@ def _sample(conn: psycopg2.extensions.connection, dbname: str) -> dict[str, obje
     """Take one sample of the catalog views, returning a JSON-serialisable record."""
     record: dict[str, object] = {
         "ts": time.time(),
-        "iso": datetime.now(timezone.utc).isoformat(),
+        "iso": datetime.now(UTC).isoformat(),
     }
     with conn.cursor() as cur:
         cur.execute(_ACTIVITY_STATE_SQL, (dbname, _APPLICATION_NAME))
@@ -375,7 +375,7 @@ def main(argv: list[str] | None = None) -> int:
             try:
                 record = _sample(conn, args.dbname)
             except psycopg2.Error as exc:
-                record = {"ts": time.time(), "iso": datetime.now(timezone.utc).isoformat(), "sample_error": str(exc)}
+                record = {"ts": time.time(), "iso": datetime.now(UTC).isoformat(), "sample_error": str(exc)}
                 # A dropped/timed-out connection (e.g. across a Postgres restart) is
                 # recovered rather than fatal, since the run tunes and restarts PG.
                 try:

--- a/tests/stress/pg_prober.py
+++ b/tests/stress/pg_prober.py
@@ -24,6 +24,12 @@ lock-convoy hypothesis:
 - Lock counts confined to the ``users`` table (tuple-lock granted/waiting and
   the total waiting across modes), which localise contention to the hot-user
   row family.
+- Per-relation tuple-lock counts (granted and waiting) bucketed by relation name
+  for a tracked set (``users``, ``user_stats``, ``user_records``,
+  ``worker_stats``, ``waiting_prompts``) plus an ``other`` bucket. The users-only
+  probe above cannot see contention that migrates off the users row onto the
+  sibling per-user rows still updated inline; this per-relation view attributes a
+  tuple-lock wait to whichever relation it actually lands on.
 - Blocking chains derived from ``pg_blocking_pids``: each blocked/blocker edge
   with the blocker's session state and transaction age, the blocked and blocker
   query texts (truncated), and per-chain flags marking the implicated
@@ -100,6 +106,24 @@ FROM pg_locks
 WHERE relation = (SELECT oid FROM pg_class WHERE relname = 'users' LIMIT 1)
 GROUP BY locktype, granted
 """
+
+# Per-relation tuple-lock counts. A ``tuple`` lock names its table through the
+# ``relation`` oid, so joining ``pg_locks`` to ``pg_class`` attributes each
+# row-level wait to the relation it targets. Grouping by name (rather than
+# resolving a single oid) lets a wait that has migrated off the users row onto a
+# sibling per-user row be seen where it lands instead of vanishing.
+_RELATION_TUPLE_LOCKS_SQL = """
+SELECT c.relname AS relname, l.granted AS granted, count(*) AS n
+FROM pg_locks AS l
+JOIN pg_class AS c ON c.oid = l.relation
+WHERE l.locktype = 'tuple'
+GROUP BY c.relname, l.granted
+"""
+
+# Relations whose per-user or per-worker rows are updated inline per request and
+# are the candidate homes for contention migrating off the users row. Anything
+# outside this set is folded into an ``other`` bucket.
+_TRACKED_LOCK_RELATIONS = ("users", "user_stats", "user_records", "worker_stats", "waiting_prompts")
 
 # Blocking chains derived from ``pg_blocking_pids``: one row per (blocked pid,
 # blocker pid) edge, carrying the blocker's session state and transaction age so
@@ -186,6 +210,35 @@ def _sample_users_locks(cur: psycopg2.extensions.cursor, record: dict[str, objec
     record["users_tuple_lock_waiting"] = tuple_waiting
     record["users_tuple_lock_granted"] = tuple_granted
     record["users_lock_waiting_total"] = waiting_total
+
+
+def _sample_relation_locks(cur: psycopg2.extensions.cursor, record: dict[str, object]) -> None:
+    """Fold per-relation tuple-lock counts into ``record`` (best effort).
+
+    Generalises the users-only probe so a tuple-lock wait is attributed to the
+    relation it targets (``user_stats``/``user_records`` in particular, the rows
+    an append-only kudos ledger leaves updated inline). Relations outside the
+    tracked set fall into an ``other`` bucket. A failure is attached as
+    ``relation_lock_error`` and left non-fatal, matching the users probe, so the
+    base series and the users-specific fields are never lost to this addition.
+    """
+    try:
+        cur.execute(_RELATION_TUPLE_LOCKS_SQL)
+    except psycopg2.Error as exc:
+        record["relation_lock_error"] = str(exc)
+        return
+    waiting = {name: 0 for name in _TRACKED_LOCK_RELATIONS}
+    granted = {name: 0 for name in _TRACKED_LOCK_RELATIONS}
+    waiting["other"] = 0
+    granted["other"] = 0
+    for relname, is_granted, count in cur.fetchall():
+        bucket = relname if relname in waiting else "other"
+        if is_granted:
+            granted[bucket] += int(count)
+        else:
+            waiting[bucket] += int(count)
+    record["tuple_lock_waiting_by_relation"] = waiting
+    record["tuple_lock_granted_by_relation"] = granted
 
 
 def _sample_blocking_chains(cur: psycopg2.extensions.cursor, dbname: str, record: dict[str, object]) -> None:
@@ -288,6 +341,7 @@ def _sample(conn: psycopg2.extensions.connection, dbname: str) -> dict[str, obje
         record["backlog_image"] = backlog.get("image", 0)
 
         _sample_users_locks(cur, record)
+        _sample_relation_locks(cur, record)
         _sample_blocking_chains(cur, dbname, record)
     return record
 

--- a/tests/unit/test_procgen_model_assignment.py
+++ b/tests/unit/test_procgen_model_assignment.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Model recorded by ``ProcessingGeneration.__init__``.
+
+Contract under test: a processing generation records a model that the assigned
+worker hosts and that is consistent with the waiting prompt's model constraint.
+
+When no explicit model is passed, ``ProcessingGeneration.__init__``
+(``horde/classes/base/processing_generation.py``) derives the model from two
+data sources read at different points: the waiting prompt's model list and the
+worker's persisted model list (via ``Worker.get_model_names``, a Redis-cached
+read). These tests pin the recorded model against the worker's authoritative
+hosted-model set across a range of overlap, batching, and model-change scenarios.
+
+All tests use ``fake_redis`` because the worker model lookup is Redis-cached via
+``Worker.get_model_names`` / ``refresh_model_cache``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from horde.classes.base.worker import WorkerModel
+from horde.classes.kobold.processing_generation import TextProcessingGeneration
+from horde.classes.kobold.waiting_prompt import TextWaitingPrompt
+from horde.classes.kobold.worker import TextWorker
+from horde.flask import db
+
+pytestmark = pytest.mark.unit
+
+
+def _make_text_worker(db_session: Any, user: Any, *, name: str, models: list[str]) -> TextWorker:
+    """Create and persist a ``TextWorker`` hosting ``models`` via the public write path."""
+    worker = TextWorker(user_id=user.id, name=name)
+    db_session.add(worker)
+    db_session.commit()
+    if models:
+        worker.set_models(models)
+    return worker
+
+
+def _make_text_wp(db_session: Any, user: Any, *, models: list[str], jobs: int = 1) -> TextWaitingPrompt:
+    """Create and persist a ``TextWaitingPrompt`` constrained to ``models``."""
+    wp = TextWaitingPrompt(
+        worker_ids=[],
+        models=models,
+        prompt="a unit-test prompt",
+        user_id=user.id,
+        params={"n": jobs, "max_length": 80, "max_context_length": 2048},
+    )
+    db_session.commit()
+    return wp
+
+
+def _procgens_for_wp(wp: TextWaitingPrompt) -> list[TextProcessingGeneration]:
+    return db.session.query(TextProcessingGeneration).filter(TextProcessingGeneration.wp_id == wp.id).all()
+
+
+def _worker_hosted_models(worker: TextWorker) -> list[str]:
+    """Return the worker's hosted models from the ``worker_models`` table.
+
+    The ``worker_models`` table is authoritative for what a worker hosts, so it
+    is the correct set against which a recorded model's validity is judged.
+    """
+    return [row.model for row in db.session.query(WorkerModel.model).filter(WorkerModel.worker_id == worker.id).all()]
+
+
+class TestRecordedModelIsHostedByWorker:
+    """A recorded model is always one the assigned worker hosts."""
+
+    def test_single_wp_model_disjoint_from_worker(self, db_session, fake_redis, make_user):
+        # Worker hosts model_alpha; the prompt is constrained to model_beta.
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_alpha_only", models=["model_alpha"])
+        wp = _make_text_wp(db_session, user, models=["model_beta"])
+
+        wp.start_generation(worker)
+
+        procgens = _procgens_for_wp(wp)
+        assert len(procgens) == 1
+        hosted_models = _worker_hosted_models(worker)
+        assert procgens[0].model in hosted_models
+
+    def test_multiple_wp_models_disjoint_from_worker(self, db_session, fake_redis, make_user):
+        # Worker hosts model_alpha; the prompt allows model_beta or model_gamma.
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_alpha_only_multi", models=["model_alpha"])
+        wp = _make_text_wp(db_session, user, models=["model_beta", "model_gamma"])
+
+        wp.start_generation(worker)
+
+        procgens = _procgens_for_wp(wp)
+        assert len(procgens) == 1
+        hosted_models = _worker_hosted_models(worker)
+        assert procgens[0].model in hosted_models
+
+
+class TestRecordedModelAfterWorkerModelsChange:
+    """A recorded model is one the worker hosts even when its model set changes
+    between the prompt match and the generation's creation.
+
+    A worker running multiple bridges pops concurrently; ``set_models`` runs on
+    every pop, so the worker's persisted model set can change between the match
+    (made against the prompt's model list) and ``ProcessingGeneration.__init__``.
+    The scenario is modelled by changing the worker's models after the prompt is
+    created but before ``start_generation``.
+    """
+
+    def test_worker_models_changed_before_generation(self, db_session, fake_redis, make_user):
+        user = make_user()
+        # At match time the worker hosts model_beta and the prompt requests it.
+        worker = _make_text_worker(db_session, user, name="worker_multibridge", models=["model_beta"])
+        wp = _make_text_wp(db_session, user, models=["model_beta"])
+
+        # The worker's model set changes before this generation is created.
+        worker.set_models(["model_alpha"])
+
+        wp.start_generation(worker)
+
+        procgens = _procgens_for_wp(wp)
+        assert len(procgens) == 1
+        hosted_models = _worker_hosted_models(worker)
+        assert procgens[0].model in hosted_models
+
+
+class TestSingleSharedModel:
+    """A single shared model between worker and prompt is the one recorded."""
+
+    def test_shared_model_is_recorded(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_shared", models=["model_shared"])
+        wp = _make_text_wp(db_session, user, models=["model_shared"])
+
+        wp.start_generation(worker)
+
+        procgens = _procgens_for_wp(wp)
+        assert len(procgens) == 1
+        assert procgens[0].model == "model_shared"
+
+
+class TestMultipleOverlap:
+    """With several shared models, the recorded model is one of the shared set."""
+
+    def test_recorded_model_is_within_overlap(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_overlap", models=["model_a", "model_b", "model_c"])
+        wp = _make_text_wp(db_session, user, models=["model_b", "model_c"])
+
+        wp.start_generation(worker)
+
+        procgens = _procgens_for_wp(wp)
+        assert len(procgens) == 1
+        assert procgens[0].model in {"model_b", "model_c"}
+
+
+class TestNoModelConstraint:
+    """An unconstrained prompt records one of the worker's own models."""
+
+    def test_recorded_model_is_a_worker_model(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_unconstrained", models=["model_x", "model_y"])
+        wp = _make_text_wp(db_session, user, models=[])
+
+        wp.start_generation(worker)
+
+        procgens = _procgens_for_wp(wp)
+        assert len(procgens) == 1
+        assert procgens[0].model in set(_worker_hosted_models(worker))
+
+
+class TestExplicitModelKwarg:
+    """An explicit ``model=`` argument is recorded verbatim."""
+
+    def test_explicit_model_is_recorded_verbatim(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_explicit", models=["model_a", "model_b"])
+        wp = _make_text_wp(db_session, user, models=["model_a"])
+
+        procgen = TextProcessingGeneration(wp_id=wp.id, worker_id=worker.id, model="model_explicit")
+
+        assert procgen.model == "model_explicit"
+
+
+class TestBatching:
+    """All procgens in a single batched pop record the same model."""
+
+    def test_batched_procgens_share_a_single_model(self, db_session, fake_redis, make_user):
+        batch_size = 3
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_batch", models=["model_a", "model_b", "model_c"])
+        wp = _make_text_wp(db_session, user, models=["model_b", "model_c"], jobs=batch_size)
+
+        wp.start_generation(worker, amount=batch_size)
+
+        procgens = _procgens_for_wp(wp)
+        assert len(procgens) == batch_size
+        recorded_models = {procgen.model for procgen in procgens}
+        assert len(recorded_models) == 1
+        assert recorded_models.pop() in {"model_b", "model_c"}

--- a/tests/unit/test_worker_model_cache.py
+++ b/tests/unit/test_worker_model_cache.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Coherence between ``Worker.set_models`` and ``Worker.get_model_names``.
+
+Contract under test: after ``set_models(models)`` commits, ``get_model_names()``
+returns those models.
+
+``set_models`` (``horde/classes/base/worker.py``) writes the model list to both
+the ``worker_models`` table and a Redis cache (``worker_{id}_model_cache``) that
+``get_model_names`` and the registry consume. The cache entry is refreshed from
+the ``self.models`` relationship collection, with a 600s TTL. The Flask session
+uses ``expire_on_commit=False`` (``horde/flask.py``), so an ORM collection loaded
+before a commit remains loaded afterward; whether ``set_models`` reads the cache
+or the collection therefore depends on the cache state when it runs. These tests
+exercise ``get_model_names`` (the public read surface) after ``set_models`` (the
+public write surface) across those scenarios.
+
+All tests use ``fake_redis`` because the model cache lives in Redis.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from horde.classes.base.worker import WorkerModel
+from horde.classes.kobold.worker import TextWorker
+from horde.flask import db
+
+pytestmark = pytest.mark.unit
+
+
+def _model_cache_key(worker: TextWorker) -> str:
+    return f"worker_{worker.id}_model_cache"
+
+
+def _make_text_worker(db_session: Any, user: Any, *, name: str) -> TextWorker:
+    """Create and persist a bare ``TextWorker`` with no models yet."""
+    worker = TextWorker(user_id=user.id, name=name)
+    db_session.add(worker)
+    db_session.commit()
+    return worker
+
+
+def _worker_model_rows(worker: TextWorker) -> set[str]:
+    """Return the worker's models from the authoritative ``worker_models`` table."""
+    return {row.model for row in db.session.query(WorkerModel.model).filter(WorkerModel.worker_id == worker.id).all()}
+
+
+class TestFreshWorkerModelPublication:
+    """The first ``set_models`` on a worker publishes those models through ``get_model_names``."""
+
+    def test_lookup_reflects_freshly_set_models(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_fresh_cache")
+
+        worker.set_models(["model_one"])
+
+        assert worker.get_model_names() == ["model_one"]
+
+
+class TestModelChangeWithExpiredCache:
+    """Changing models when the cache has expired publishes the new list.
+
+    The 600s cache entry is absent (modelled by deleting the key), as it would be
+    once its TTL lapses, and the worker re-declares a different model set.
+    """
+
+    def test_model_change_after_cache_expiry_publishes_new_models(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_change_miss")
+        worker.set_models(["model_old"])
+
+        # A fresh request context (one worker instance per request) with the
+        # cache entry no longer present.
+        db.session.expire_all()
+        worker = db.session.query(TextWorker).filter(TextWorker.id == worker.id).one()
+        fake_redis.horde_r_delete(_model_cache_key(worker))
+
+        worker.set_models(["model_new"])
+
+        assert worker.get_model_names() == ["model_new"]
+
+
+class TestModelChangeWithWarmCache:
+    """Changing models when the cache is warm publishes the new list."""
+
+    def test_model_change_with_warm_cache_publishes_new_models(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_change_hit")
+        worker.set_models(["model_old"])
+
+        # Pre-warm the cache with the current value and ensure the relationship
+        # collection is not already loaded in this session.
+        fake_redis.horde_r_setex(_model_cache_key(worker), timedelta(seconds=600), json.dumps(["model_old"]))
+        db.session.expire(worker, ["models"])
+
+        worker.set_models(["model_new"])
+
+        assert worker.get_model_names() == ["model_new"]
+
+
+class TestDatabaseRowsReflectLastCall:
+    """The ``worker_models`` table matches the last ``set_models`` call."""
+
+    def test_db_rows_match_last_set_models_call(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="worker_db_rows")
+
+        worker.set_models(["model_alpha"])
+        assert _worker_model_rows(worker) == {"model_alpha"}
+
+        worker.set_models(["model_beta", "model_gamma"])
+        assert _worker_model_rows(worker) == {"model_beta", "model_gamma"}

--- a/tests/unit/test_worker_softprompt_cache.py
+++ b/tests/unit/test_worker_softprompt_cache.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Coherence between ``TextWorker.set_softprompts`` and ``TextWorker.get_softprompt_names``.
+
+Contract under test: after ``set_softprompts(softprompts)`` runs, ``get_softprompt_names()``
+returns those softprompts.
+
+``set_softprompts`` (``horde/classes/kobold/worker.py``) writes the softprompt list to
+both the ``text_worker_softprompts`` table and a Redis cache
+(``worker_{id}_softprompts_cache``) that ``get_softprompt_names`` consumes, refreshed
+from the ``self.softprompts`` relationship collection with a 600s TTL. The mechanism
+mirrors ``Worker.set_models`` / ``Worker.get_model_names``: whether the refresh observes
+the newly written rows or a stale relationship collection depends on the cache and
+session state when it runs. The Flask session uses ``expire_on_commit=False``
+(``horde/flask.py``), so a collection loaded before a write stays loaded afterwards.
+These tests exercise ``get_softprompt_names`` (the public read surface) after
+``set_softprompts`` (the public write surface) across those scenarios.
+
+All tests use ``fake_redis`` because the softprompt cache lives in Redis.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from horde.classes.kobold.worker import TextWorker, TextWorkerSoftprompts
+from horde.flask import db
+
+pytestmark = pytest.mark.unit
+
+
+def _softprompt_cache_key(worker: TextWorker) -> str:
+    return f"worker_{worker.id}_softprompts_cache"
+
+
+def _make_text_worker(db_session: Any, user: Any, *, name: str) -> TextWorker:
+    """Create and persist a bare ``TextWorker`` with no softprompts yet."""
+    worker = TextWorker(user_id=user.id, name=name)
+    db_session.add(worker)
+    db_session.commit()
+    return worker
+
+
+def _worker_softprompt_rows(worker: TextWorker) -> set[str]:
+    """Return the worker's softprompts from the authoritative ``text_worker_softprompts`` table."""
+    rows = db.session.query(TextWorkerSoftprompts.softprompt).filter(TextWorkerSoftprompts.worker_id == worker.id).all()
+    return {row.softprompt for row in rows}
+
+
+class TestFreshWorkerSoftpromptPublication:
+    """The first ``set_softprompts`` on a worker publishes those softprompts through ``get_softprompt_names``."""
+
+    def test_lookup_reflects_freshly_set_softprompts(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="text_worker_fresh_sp_cache")
+
+        worker.set_softprompts(["sp_one"])
+
+        assert worker.get_softprompt_names() == ["sp_one"]
+
+
+class TestSoftpromptChangeWithExpiredCache:
+    """Changing softprompts when the cache has expired publishes the new list.
+
+    The 600s cache entry is absent (modelled by deleting the key), as it would be
+    once its TTL lapses, and the worker re-declares a different softprompt set.
+    """
+
+    def test_softprompt_change_after_cache_expiry_publishes_new_softprompts(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="text_worker_sp_change_miss")
+        worker.set_softprompts(["sp_old"])
+
+        # A fresh request context (one worker instance per request) with the
+        # cache entry no longer present.
+        db.session.expire_all()
+        worker = db.session.query(TextWorker).filter(TextWorker.id == worker.id).one()
+        fake_redis.horde_r_delete(_softprompt_cache_key(worker))
+
+        worker.set_softprompts(["sp_new"])
+
+        assert worker.get_softprompt_names() == ["sp_new"]
+
+
+class TestSoftpromptChangeWithWarmCache:
+    """Changing softprompts when the cache is warm and the relationship is unloaded publishes the new list."""
+
+    def test_softprompt_change_with_warm_cache_publishes_new_softprompts(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="text_worker_sp_change_hit")
+        worker.set_softprompts(["sp_old"])
+
+        # Pre-warm the cache with the current value and ensure the relationship
+        # collection is not already loaded in this session.
+        fake_redis.horde_r_setex(_softprompt_cache_key(worker), timedelta(seconds=600), json.dumps(["sp_old"]))
+        db.session.expire(worker, ["softprompts"])
+
+        worker.set_softprompts(["sp_new"])
+
+        assert worker.get_softprompt_names() == ["sp_new"]
+
+
+class TestDatabaseRowsReflectLastCall:
+    """The ``text_worker_softprompts`` table matches the last ``set_softprompts`` call."""
+
+    def test_db_rows_match_last_set_softprompts_call(self, db_session, fake_redis, make_user):
+        user = make_user()
+        worker = _make_text_worker(db_session, user, name="text_worker_sp_db_rows")
+
+        worker.set_softprompts(["sp_alpha"])
+        assert _worker_softprompt_rows(worker) == {"sp_alpha"}
+
+        worker.set_softprompts(["sp_beta", "sp_gamma"])
+        assert _worker_softprompt_rows(worker) == {"sp_beta", "sp_gamma"}

--- a/tests/unit/test_wp_has_valid_workers.py
+++ b/tests/unit/test_wp_has_valid_workers.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit coverage for ``horde.database.functions.wp_has_valid_workers``.
+
+``wp_has_valid_workers`` decides whether a waiting prompt is servable. It draws
+on two distinct sources of truth about a request:
+
+- A worker-availability query (``horde/database/functions.py``) that selects
+  currently non-stale workers (``last_check_in`` within 300s) matching the
+  request's model and parameter constraints, then re-checks each with a
+  Python-side ``worker.can_generate``.
+- The request's live generation state, exposed by
+  ``WaitingPrompt.count_processing_gens`` (``horde/classes/base/waiting_prompt.py``),
+  which counts finished, restarted, and in-flight (processing) procgens.
+
+The verdict is memoized in Redis under ``wp_validity_{wp.id}`` with a 60s TTL.
+
+The behavioral contracts exercised here: a request that is actively being
+generated is possible even once its serving worker goes stale, and a memoized
+verdict must agree with the live worker and generation state rather than pin an
+outdated answer. The remaining tests cover the availability query's
+model/staleness/capacity filters and the processing-count bucketing.
+
+Every test uses ``fake_redis`` because the verdict is Redis-memoized and worker
+model lookups are Redis-cached via ``Worker.get_model_names``. The
+``_stub_model_reference`` autouse fixture pins the image model reference to a
+minimal in-memory dict so ``can_generate`` and procgen construction stay
+hermetic (no network dependency on the remote model reference).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from horde.classes.base.worker import WorkerModel
+from horde.classes.stable.processing_generation import ImageProcessingGeneration
+from horde.classes.stable.waiting_prompt import ImageWaitingPrompt
+from horde.classes.stable.worker import ImageWorker
+from horde.database import functions as f
+from horde.enums import UserRoleTypes
+from horde.flask import db
+
+pytestmark = pytest.mark.unit
+
+# The requested resolution is held constant so worker ``max_pixels`` is the only
+# lever for the image-branch capacity control.
+_WP_WIDTH = 512
+_WP_HEIGHT = 512
+_HOSTED_MODEL = "stable_diffusion"
+
+
+@pytest.fixture(autouse=True)
+def _stub_model_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the image model reference to a minimal in-memory dict.
+
+    ``ImageWorker.can_generate`` and ``ImageProcessingGeneration`` consult
+    ``model_reference`` (normally fetched over the network at import time). We
+    substitute a tiny reference so the tests are hermetic and deterministic.
+    """
+    from horde import model_reference as model_reference_module
+
+    minimal_reference = {_HOSTED_MODEL: {"baseline": "stable diffusion 1"}}
+    monkeypatch.setattr(model_reference_module.model_reference, "reference", minimal_reference)
+
+
+def _validity_cache_key(wp: ImageWaitingPrompt) -> str:
+    return f"wp_validity_{wp.id}"
+
+
+def _make_trusted_user(make_user: Any, make_user_role: Any) -> Any:
+    """Create a user trusted enough to satisfy the ``can_generate`` trust gate.
+
+    ``ImageWorker.can_generate`` rejects a worker whose owner is untrusted when
+    the request is neither ``safe_ip`` nor owned by a trusted user. Owning the
+    worker (and the WP) with a trusted user keeps every non-target gate open.
+    """
+    user = make_user()
+    make_user_role(user, UserRoleTypes.TRUSTED, value=True)
+    return user
+
+
+def _make_image_worker(
+    user: Any,
+    *,
+    models: tuple[str, ...] = (_HOSTED_MODEL,),
+    max_pixels: int = 1024 * 1024,
+    stale: bool = False,
+) -> ImageWorker:
+    """Create and persist an ``ImageWorker`` hosting ``models``.
+
+    ``WorkerModel`` rows are inserted directly rather than via ``set_models`` so
+    the worker does not depend on the model appearing in the (network-sourced)
+    model reference. ``stale`` backdates ``last_check_in`` past the 300s cutoff.
+    """
+    last_check_in = datetime.utcnow() - timedelta(seconds=400) if stale else datetime.utcnow()
+    worker = ImageWorker(
+        user_id=user.id,
+        name=f"worker_{uuid.uuid4().hex[:12]}",
+        max_pixels=max_pixels,
+        last_check_in=last_check_in,
+    )
+    db.session.add(worker)
+    db.session.commit()
+    for model_name in models:
+        db.session.add(WorkerModel(worker_id=worker.id, model=model_name))
+    db.session.commit()
+    return worker
+
+
+def _make_image_wp(
+    user: Any,
+    *,
+    models: tuple[str, ...] = (_HOSTED_MODEL,),
+    width: int = _WP_WIDTH,
+    height: int = _WP_HEIGHT,
+    n: int = 1,
+) -> ImageWaitingPrompt:
+    """Create and persist an ``ImageWaitingPrompt`` constrained to ``models``."""
+    wp = ImageWaitingPrompt(
+        [],
+        list(models),
+        prompt="a unit-test prompt",
+        user_id=user.id,
+        params={
+            "n": n,
+            "width": width,
+            "height": height,
+            "steps": 10,
+            "sampler_name": "k_euler_a",
+            "karras": True,
+        },
+    )
+    db.session.commit()
+    return wp
+
+
+def _make_procgen(
+    wp: ImageWaitingPrompt,
+    worker: ImageWorker,
+    *,
+    generation: str | None = None,
+    faulted: bool = False,
+) -> ImageProcessingGeneration:
+    """Create and persist an ``ImageProcessingGeneration`` in a chosen state.
+
+    A pending (in-flight) procgen has ``generation is None`` and ``faulted``
+    False. Setting ``generation`` marks it completed; ``faulted`` marks it
+    restarted. The state is written directly rather than via ``set_generation``
+    / ``abort`` to avoid the kudos, R2 upload and webhook machinery those carry,
+    none of which affects the bucketing or validity logic under test.
+    """
+    procgen = ImageProcessingGeneration(wp_id=wp.id, worker_id=worker.id, model=_HOSTED_MODEL)
+    if generation is not None:
+        procgen.generation = generation
+    if faulted:
+        procgen.faulted = True
+    db.session.commit()
+    return procgen
+
+
+class TestInFlightImpliesPossible:
+    """A request with an in-flight generation is possible even if its worker is stale."""
+
+    def test_in_flight_procgen_survives_worker_going_stale(self, db_session, fake_redis, make_user, make_user_role):
+        # The worker popped the whole request (remaining n == 0) and is now mid
+        # generation, but its check-in has aged past the 300s staleness cutoff.
+        # An in-flight generation means the request is still being served, so it
+        # remains possible regardless of the serving worker's staleness.
+        user = _make_trusted_user(make_user, make_user_role)
+        wp = _make_image_wp(user)
+        worker = _make_image_worker(user)
+        _make_procgen(wp, worker)
+
+        # The whole request has been popped; nothing remains queued.
+        wp.n = 0
+        db.session.commit()
+
+        # The worker that popped the job has now gone quiet past the stale cutoff.
+        worker.last_check_in = datetime.utcnow() - timedelta(seconds=400)
+        db.session.commit()
+
+        # Ensure no cached verdict can satisfy the assertion for the wrong reason.
+        fake_redis.horde_r_delete(_validity_cache_key(wp))
+
+        assert f.wp_has_valid_workers(wp) is True
+
+
+class TestStaleCacheMustNotContradictLiveState:
+    """A memoized validity verdict does not contradict the live worker and generation state."""
+
+    def test_primed_false_verdict_does_not_survive_a_valid_worker(self, db_session, fake_redis, make_user, make_user_role):
+        # Construct the scenario of a "not possible" verdict memoized while no
+        # worker existed, then bring the live state up to date: a fresh, capable
+        # worker appears and picks up the job (processing > 0). The reported
+        # verdict must reflect that live state rather than the earlier memoized
+        # answer.
+        user = _make_trusted_user(make_user, make_user_role)
+        wp = _make_image_wp(user)
+
+        fake_redis.horde_r_setex(_validity_cache_key(wp), timedelta(seconds=60), 0)
+
+        worker = _make_image_worker(user)
+        _make_procgen(wp, worker)
+        wp.n = 0
+        db.session.commit()
+
+        assert f.wp_has_valid_workers(wp) is True
+
+
+class TestNoWorkers:
+    """A request with no workers and nothing processing is not possible."""
+
+    def test_no_workers_returns_false(self, db_session, fake_redis, make_user, make_user_role):
+        user = _make_trusted_user(make_user, make_user_role)
+        wp = _make_image_wp(user)
+
+        assert f.wp_has_valid_workers(wp) is False
+
+
+class TestFreshCapableWorker:
+    """A fresh worker hosting the requested model makes the request possible."""
+
+    def test_fresh_worker_makes_request_possible(self, db_session, fake_redis, make_user, make_user_role):
+        user = _make_trusted_user(make_user, make_user_role)
+        wp = _make_image_wp(user)
+        _make_image_worker(user)
+
+        assert f.wp_has_valid_workers(wp) is True
+
+
+class TestWrongModelWorker:
+    """A worker hosting only a different model cannot serve the request."""
+
+    def test_worker_with_only_other_model_returns_false(self, db_session, fake_redis, make_user, make_user_role):
+        user = _make_trusted_user(make_user, make_user_role)
+        wp = _make_image_wp(user)
+        _make_image_worker(user, models=("some_other_model",))
+
+        assert f.wp_has_valid_workers(wp) is False
+
+
+class TestStaleCapableWorker:
+    """A capable but stale worker, with nothing processing, is not possible."""
+
+    def test_stale_worker_returns_false(self, db_session, fake_redis, make_user, make_user_role):
+        user = _make_trusted_user(make_user, make_user_role)
+        wp = _make_image_wp(user)
+        _make_image_worker(user, stale=True)
+
+        assert f.wp_has_valid_workers(wp) is False
+
+
+class TestImageCapacityConstraint:
+    """A worker whose max_pixels is below the requested resolution cannot serve it."""
+
+    def test_worker_below_requested_pixels_returns_false(self, db_session, fake_redis, make_user, make_user_role):
+        user = _make_trusted_user(make_user, make_user_role)
+        wp = _make_image_wp(user)
+        # 256*256 < 512*512, so the ``wp.width * wp.height <= max_pixels`` filter
+        # excludes this otherwise-valid worker.
+        _make_image_worker(user, max_pixels=256 * 256)
+
+        assert f.wp_has_valid_workers(wp) is False
+
+
+class TestCountProcessingGensBucketing:
+    """count_processing_gens buckets completed, faulted, and in-flight procgens."""
+
+    def test_one_of_each_state_is_bucketed_correctly(self, db_session, fake_redis, make_user, make_user_role):
+        user = _make_trusted_user(make_user, make_user_role)
+        wp = _make_image_wp(user)
+        worker = _make_image_worker(user)
+
+        _make_procgen(wp, worker, generation="R2")  # completed -> finished
+        _make_procgen(wp, worker, faulted=True)  # faulted -> restarted
+        _make_procgen(wp, worker)  # pending -> processing
+
+        counts = wp.count_processing_gens()
+
+        assert counts["finished"] == 1
+        assert counts["restarted"] == 1
+        assert counts["processing"] == 1

--- a/tests/unit/test_wp_status_consistency.py
+++ b/tests/unit/test_wp_status_consistency.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit coverage for the internal consistency of ``WaitingPrompt.get_status``.
+
+``get_status`` assembles a status payload from three sources that are read at
+different moments: ``self.n``, loaded with the instance; the validity verdict,
+sampled by the caller and passed in; and the generation counts, read from
+``processing_gens`` when the payload is built. A generation that starts in
+between leaves the earlier two describing a state the counts have already moved
+past.
+
+The payload is a single answer to a single client question, so the contracts
+exercised here are the ones a client can check without a second request: a
+request reported as processing is reported as possible, and the outstanding,
+in-flight, and finished generations never exceed the ``jobs`` the request
+originally asked for.
+
+Every test uses ``fake_redis`` because the status path reads Redis-cached
+performance and worker data. The ``_stub_model_reference`` autouse fixture pins
+the image model reference to a minimal in-memory dict so procgen construction
+stays hermetic.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from horde.classes.base.worker import WorkerModel
+from horde.classes.stable.processing_generation import ImageProcessingGeneration
+from horde.classes.stable.waiting_prompt import ImageWaitingPrompt
+from horde.classes.stable.worker import ImageWorker
+from horde.flask import db
+
+pytestmark = pytest.mark.unit
+
+_HOSTED_MODEL = "stable_diffusion"
+
+
+@pytest.fixture(autouse=True)
+def _stub_model_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the image model reference to a minimal in-memory dict."""
+    from horde import model_reference as model_reference_module
+
+    minimal_reference = {_HOSTED_MODEL: {"baseline": "stable diffusion 1"}}
+    monkeypatch.setattr(model_reference_module.model_reference, "reference", minimal_reference)
+
+
+def _make_worker(user: Any) -> ImageWorker:
+    """Create and persist an ``ImageWorker`` hosting the reference model."""
+    worker = ImageWorker(
+        user_id=user.id,
+        name=f"worker_{uuid.uuid4().hex[:12]}",
+        max_pixels=1024 * 1024,
+        last_check_in=datetime.utcnow(),
+    )
+    db.session.add(worker)
+    db.session.commit()
+    db.session.add(WorkerModel(worker_id=worker.id, model=_HOSTED_MODEL))
+    db.session.commit()
+    return worker
+
+
+def _make_wp(user: Any, *, n: int = 1) -> ImageWaitingPrompt:
+    """Create and persist an ``ImageWaitingPrompt`` requesting ``n`` generations."""
+    wp = ImageWaitingPrompt(
+        [],
+        [_HOSTED_MODEL],
+        prompt="a unit-test prompt",
+        user_id=user.id,
+        params={
+            "n": n,
+            "width": 512,
+            "height": 512,
+            "steps": 10,
+            "sampler_name": "k_euler_a",
+            "karras": True,
+        },
+    )
+    db.session.commit()
+    return wp
+
+
+def _make_procgen(
+    wp: ImageWaitingPrompt,
+    worker: ImageWorker,
+    *,
+    generation: str | None = None,
+    faulted: bool = False,
+) -> ImageProcessingGeneration:
+    """Create and persist a procgen in a chosen state.
+
+    An in-flight procgen has ``generation is None`` and ``faulted`` False.
+    Setting ``generation`` marks it completed; ``faulted`` marks it restarted.
+    The state is written directly rather than via ``set_generation`` / ``abort``
+    to avoid the kudos, R2 upload and webhook machinery those carry, none of
+    which affects the counts under test.
+    """
+    procgen = ImageProcessingGeneration(wp_id=wp.id, worker_id=worker.id, model=_HOSTED_MODEL)
+    if generation is not None:
+        procgen.generation = generation
+    if faulted:
+        procgen.faulted = True
+    db.session.commit()
+    return procgen
+
+
+def _status(wp: ImageWaitingPrompt, *, has_valid_workers: bool = True) -> dict[str, Any]:
+    """Return ``wp.get_status`` with neutral queue and worker-population inputs.
+
+    The queue statistics and worker population only feed the wait-time estimate,
+    which none of these contracts depend on, so they are held at fixed neutral
+    values.
+    """
+    return wp.get_status(
+        request_avg=1.0,
+        active_worker_count=(1, 1),
+        has_valid_workers=has_valid_workers,
+        wp_queue_stats=(0, 0, 0),
+        lite=True,
+    )
+
+
+class TestPossibilityAgreesWithTheProcessingCount:
+    """A request reported as processing is reported as possible."""
+
+    def test_in_flight_generation_overrides_an_impossible_verdict(self, db_session, fake_redis, make_user):
+        # The verdict passed in describes the request before its generation
+        # started; the counts describe it after. A client seeing processing=1
+        # alongside is_possible=false cannot act on either answer.
+        user = make_user()
+        wp = _make_wp(user)
+        worker = _make_worker(user)
+        _make_procgen(wp, worker)
+        wp.n = 0
+        db.session.commit()
+
+        status = _status(wp, has_valid_workers=False)
+
+        assert status["processing"] == 1
+        assert status["is_possible"] is True
+
+    def test_verdict_is_reported_unchanged_when_nothing_is_processing(self, db_session, fake_redis, make_user):
+        # With no generation in flight there is nothing to contradict, so the
+        # caller's verdict stands: a request no worker can serve stays impossible.
+        user = make_user()
+        wp = _make_wp(user)
+
+        assert _status(wp, has_valid_workers=False)["is_possible"] is False
+        assert _status(wp, has_valid_workers=True)["is_possible"] is True
+
+    def test_finished_generation_does_not_force_possible(self, db_session, fake_redis, make_user):
+        # A completed generation is no longer in flight, so it says nothing about
+        # whether the remaining work can be served.
+        user = make_user()
+        wp = _make_wp(user, n=2)
+        worker = _make_worker(user)
+        _make_procgen(wp, worker, generation="done")
+        wp.n = 1
+        db.session.commit()
+
+        status = _status(wp, has_valid_workers=False)
+
+        assert status["finished"] == 1
+        assert status["processing"] == 0
+        assert status["is_possible"] is False
+
+
+class TestOutstandingGenerationsNeverExceedTheRequest:
+    """Waiting, processing, and finished generations stay within the requested ``jobs``."""
+
+    def test_waiting_excludes_a_slot_already_claimed_by_a_generation(self, db_session, fake_redis, make_user):
+        # `n` still holds the value read before the generation started, so it
+        # counts a slot the procgen below has already claimed. Reporting both
+        # would describe two generations for a request that asked for one.
+        user = make_user()
+        wp = _make_wp(user, n=1)
+        worker = _make_worker(user)
+        _make_procgen(wp, worker)
+
+        status = _status(wp)
+
+        assert wp.jobs == 1
+        assert status["waiting"] == 0
+        assert status["processing"] == 1
+        assert status["waiting"] + status["processing"] + status["finished"] == wp.jobs
+
+    def test_multi_generation_request_reports_the_unclaimed_remainder(self, db_session, fake_redis, make_user):
+        user = make_user()
+        wp = _make_wp(user, n=3)
+        worker = _make_worker(user)
+        _make_procgen(wp, worker)
+        _make_procgen(wp, worker, generation="done")
+        wp.n = 1
+        db.session.commit()
+
+        status = _status(wp)
+
+        assert status["waiting"] == 1
+        assert status["processing"] == 1
+        assert status["finished"] == 1
+        assert status["waiting"] + status["processing"] + status["finished"] == wp.jobs
+
+    def test_faulted_generation_returns_its_slot_to_waiting(self, db_session, fake_redis, make_user):
+        # A faulted generation hands its slot back to `n` for another worker and
+        # is reported separately as `restarted`, so it does not consume one of
+        # the request's jobs.
+        user = make_user()
+        wp = _make_wp(user, n=1)
+        worker = _make_worker(user)
+        _make_procgen(wp, worker, faulted=True)
+
+        status = _status(wp)
+
+        assert status["restarted"] == 1
+        assert status["waiting"] == 1
+        assert status["processing"] == 0
+
+    def test_cancelled_request_reports_nothing_waiting(self, db_session, fake_redis, make_user):
+        # Cancellation zeroes `n` while leaving the unclaimed jobs unstarted, so
+        # waiting must follow `n` rather than the request's original size.
+        user = make_user()
+        wp = _make_wp(user, n=3)
+        wp.n = 0
+        db.session.commit()
+
+        assert _status(wp)["waiting"] == 0


### PR DESCRIPTION
Three correctness bugs made the horde misreport what workers host, which model actually served a generation, and whether a queued request was still possible. This PR fixes all three. 

It also adds an env-gated rate-limiter toggle and a durable load-testing suite under `tests/stress/` (combined ~4,800 lines), which the rest of this series uses for pre/post evidence. The actual production changes are <100 lines; most of the diff is the reproduction testing, which will also serve as scaffolding for identifying future problems.

- Fixes #530, which was reported by @ravenwright89-lgtm and @Efreak. My thanks to them for providing good detail so I could track down the issue.

## Problems and fixes

### 1. Worker model/softprompt caches could publish stale or empty lists

The Redis caches for worker models and softprompts were serialized from ORM relationship collections. With `expire_on_commit=False`, those collections can still hold pre-change rows; a cache miss during `set_models` or `set_softprompts` then republished a stale (or, for new workers, empty) list with a fresh TTL. This presented as the worker registry contradicting what a worker just declared, for up to a TTL.

Fix: `refresh_model_cache` and `refresh_softprompt_cache` now serialize from direct queries of the authoritative rows (`WorkerModel`, `TextWorkerSoftprompts`) rather than the relationship collections.

- https://github.com/Haidra-Org/AI-Horde/blob/7a104e8d0e96a86cd21cbb48ede0f7834489d81a/horde/classes/base/worker.py#L602-L616
- https://github.com/Haidra-Org/AI-Horde/blob/7a104e8d0e96a86cd21cbb48ede0f7834489d81a/horde/classes/kobold/worker.py#L63-L80

This issue was a regression introduced by me in the [recent telemetry+performance changes](https://github.com/Haidra-Org/AI-Horde/commit/415277541aa6e5671fe00de553d880c64caca209), which set `expire_on_commit=False` in the interest of speed. 

### 2. Generations could be recorded against a model the worker does not host

The pop SQL matches waiting prompts against the pop payload's declared model list, but the processing generation then re-derived its model from worker state read afterward. On an empty intersection it recorded a requested model the worker did not host, so status responses could contradict the worker registry.

Fix: the pop-declared model list is threaded from `JobPopTemplate.start_worker` into `start_generation`; `_select_model` picks the batch's model once from that declared list, and the derivation branch that guessed from worker state is restricted to non-pop constructions (fake generations). The unhosted-model fallback is gone.

- https://github.com/Haidra-Org/AI-Horde/blob/7a104e8d0e96a86cd21cbb48ede0f7834489d81a/horde/apis/v2/base.py#L659-L671
- https://github.com/Haidra-Org/AI-Horde/blob/7a104e8d0e96a86cd21cbb48ede0f7834489d81a/horde/classes/base/waiting_prompt.py#L325-L362

### 3. `is_possible` could report false while generations were actively in flight

`wp_has_valid_workers` evaluated only currently-eligible workers against the waiting portion of a request, and honored a 60s memoized verdict with no invalidation. A request whose generations were all picked up (or whose eligible worker went stale after pickup) could report `is_possible: false` while `processing > 0` in the same status payload.

Fix: any in-flight non-fake generation short-circuits to possible, checked live before the memoized verdict is consulted. Fake generations are excluded, consistent with processing-count bucketing.

- https://github.com/Haidra-Org/AI-Horde/blob/7a104e8d0e96a86cd21cbb48ede0f7834489d81a/horde/database/functions.py#L1509-L1534

#### Associated issue found during initial CI run

- https://github.com/Haidra-Org/AI-Horde/blob/baddf3418c8b8e5260f23cd90adb77f2bc43c58a/horde/classes/base/waiting_prompt.py#L518-L529
- https://github.com/Haidra-Org/AI-Horde/blob/baddf3418c8b8e5260f23cd90adb77f2bc43c58a/horde/classes/base/waiting_prompt.py#L566-L571

## Supporting changes

- **Env-gated rate-limiter toggle** (`HORDE_TEST_RATELIMIT_DISABLED`): load-test scenarios need to drive the server past flask-limiter's per-IP caps. Unset env keeps production behavior; the flag is applied before `init_app` so both the redis and memory-only limiter branches honor it.
  - https://github.com/Haidra-Org/AI-Horde/blob/7a104e8d0e96a86cd21cbb48ede0f7834489d81a/horde/limiter.py#L16-L37
- **Load-test suite** (`tests/stress/`, ~4,800 lines): three locust-based scenarios (hot-user lock convoy, queue pressure), analyzers, a `pg_blocking_pids` lock-chain sampler (`pg_prober.py`), and a shared stack harness. These are operator tooling, imported by nothing in `horde/`; they exist to reproduce production contention signatures and to gate the ledger series on measured evidence.

## Test plan

All new behavior is pinned by tests that fail on the pre-fix code:

- `tests/unit/test_worker_model_cache.py`, `tests/unit/test_worker_softprompt_cache.py`: first declaration, change on expired cache, change on warm cache, DB-row authority.
- `tests/unit/test_procgen_model_assignment.py`: disjoint and changed declarations, overlap selection, unconstrained prompts, explicit model, batch consistency.
- `tests/unit/test_wp_has_valid_workers.py`: in-flight short-circuit, cached-verdict bypass, worker eligibility gates, processing bucketing.

## Review touch points

- `horde/classes/base/waiting_prompt.py` (`_select_model` / `_start_generation`): the model-selection contract changed from per-procgen derivation to batch-once selection from the declared list. The empty-overlap fallback matches expectations for degenerate pops.
- `horde/database/functions.py` (`wp_has_valid_workers`): the short-circuit adds one count query per uncached validity check; it runs before the memoization read, deliberately, so a live processing count always wins over a stale cached verdict.
- `horde/limiter.py`: confirm the gate cannot engage in production (requires an explicit truthy env value).