### PR TITLE
refactor: materialize worker speed into a maintained column

### DIFF
--- a/horde/classes/base/worker.py
+++ b/horde/classes/base/worker.py
@@ -45,10 +45,16 @@ class WorkerStats(db.Model):
 class WorkerPerformance(db.Model):
     __tablename__ = "worker_performances"
     id = db.Column(db.Integer, primary_key=True)
+    # Indexed because ``Worker.record_performance`` filters this table by ``worker_id``
+    # twice per completed job (once to prune older samples, once to recompute the
+    # average that maintains ``Worker.speed``). PostgreSQL does not index foreign key
+    # columns automatically, so without this both are sequential scans of the full
+    # sample table on every job completion.
     worker_id = db.Column(
         uuid_column_type(),
         db.ForeignKey("workers.id", ondelete="CASCADE"),
         nullable=False,
+        index=True,
     )
     worker = db.relationship("Worker", back_populates="performance")
     performance = db.Column(db.Float, primary_key=False)
@@ -181,11 +187,17 @@ class WorkerTemplate(db.Model):
     # reproducing the historical CASE expression that substituted that baseline whenever
     # the average was NULL. This preserves the exact pop-filter outcomes for fresh
     # workers: image workers clear the ``>= 500000`` threshold, while text and
-    # interrogation workers stay below theirs until real samples arrive. The stored value
-    # follows COALESCE(avg, baseline) semantics, falling back only on a NULL average; it
-    # deliberately does not also treat a zero average as "no samples", unlike the former
-    # Python getter's truthiness check (the two forms already disagreed there, and the
-    # SQL form is canonical).
+    # interrogation workers stay below theirs until real samples arrive.
+    #
+    # The stored value falls back to the baseline on a zero average as well as on a NULL
+    # one, matching the former Python getter's truthiness check rather than the former
+    # SQL expression's NULL-only CASE. The two forms disagreed, and the Python form is
+    # the one that must be preserved: ``speed`` is a divisor in
+    # ``ProcessingGeneration.get_seconds_needed``, so a stored zero raises
+    # ZeroDivisionError there. The substitution is invisible to every pop filter, since
+    # zero and the baseline fall on the same side of all four thresholds
+    # (``>= 500000``, ``>= 2``, ``>= slow_speed`` where slow_speed is 3 to 5, and
+    # ``< 10``).
     speed = db.Column(db.Float, nullable=False, index=True)
 
     def __init__(self, **kwargs: Any) -> None:
@@ -436,7 +448,9 @@ class WorkerTemplate(db.Model):
         # samples (rather than incrementally) also makes this write self-healing if an
         # earlier sample write was lost.
         retained_average = db.session.query(func.avg(WorkerPerformance.performance)).filter_by(worker_id=self.id).scalar()
-        self.speed = retained_average if retained_average is not None else self._baseline_speed()
+        # A zero average falls back to the baseline alongside a NULL one; see the
+        # ``speed`` column comment for why a stored zero is not a permissible value.
+        self.speed = retained_average if retained_average else self._baseline_speed()
         if commit:
             db.session.commit()
 

--- a/horde/classes/base/worker.py
+++ b/horde/classes/base/worker.py
@@ -4,11 +4,11 @@
 
 import json
 from datetime import datetime, timedelta
+from typing import Any
 
 import logfire
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.ext.hybrid import hybrid_property
 
 from horde import vars as hv
 from horde.classes.base import settings
@@ -20,6 +20,13 @@ from horde.suspicions import SUSPICION_LOGS, Suspicions
 from horde.utils import get_db_uuid, get_message_expiry_date, is_profane, sanitize_string
 
 uuid_column_type = lambda: UUID(as_uuid=True) if not SQLITE_MODE else db.String(36)  # FIXME # noqa E731
+
+# The throughput a worker is credited with before it has recorded any performance
+# sample, expressed in "things" (megapixelsteps for image, tokens for text) per second.
+# It is scaled into the raw units the speed column stores by the worker type's divisor.
+# Kept as a named baseline so a fresh worker's speed reproduces the historical
+# substitution the old speed expression applied whenever the sample average was NULL.
+SPEED_BASELINE_THINGS_PER_SEC = 1
 
 
 class WorkerStats(db.Model):
@@ -161,22 +168,50 @@ class WorkerTemplate(db.Model):
     # TODO: Normalize this to the standard
     wtype = "image"
 
-    @hybrid_property
-    def speed(self) -> int:
-        performance_avg = db.session.query(func.avg(WorkerPerformance.performance)).filter_by(worker_id=self.id).scalar()
-        if performance_avg:
-            return performance_avg
-        # We return a baseline speed if the workers hasn't fulfilled anything
-        # in order to avoid a division by zero
-        return 1 * hv.thing_divisors[self.wtype]
+    # ``speed`` is the worker's rolling-average throughput (raw things per second),
+    # materialized on the row rather than derived on read. It was previously a
+    # hybrid_property whose SQL form embedded a correlated
+    # ``avg(worker_performances.performance)`` subquery, re-evaluated for every candidate
+    # worker in every pop candidate filter: the single largest cumulative-time query on
+    # the database. It is now maintained at the one write site (``record_performance``)
+    # and seeded on construction (``__init__``), so every reader becomes a plain column
+    # access.
+    #
+    # A worker with no samples stores the per-type baseline (see ``_baseline_speed``),
+    # reproducing the historical CASE expression that substituted that baseline whenever
+    # the average was NULL. This preserves the exact pop-filter outcomes for fresh
+    # workers: image workers clear the ``>= 500000`` threshold, while text and
+    # interrogation workers stay below theirs until real samples arrive. The stored value
+    # follows COALESCE(avg, baseline) semantics, falling back only on a NULL average; it
+    # deliberately does not also treat a zero average as "no samples", unlike the former
+    # Python getter's truthiness check (the two forms already disagreed there, and the
+    # SQL form is canonical).
+    speed = db.Column(db.Float, nullable=False, index=True)
 
-    @speed.expression
-    def speed(cls):
-        performance_avg = db.select(func.avg(WorkerPerformance.performance)).where(WorkerPerformance.worker_id == cls.id).label("speed")
-        return db.case(
-            (performance_avg == None, 1 * hv.thing_divisors[cls.wtype]),  # noqa E712
-            else_=performance_avg,
-        )
+    def __init__(self, **kwargs: Any) -> None:
+        """Seed the materialized ``speed`` to the per-type baseline on construction.
+
+        ``speed`` is NOT NULL and is maintained thereafter by ``record_performance``.
+        Seeding in ``__init__`` (the single construction chokepoint shared by every
+        worker subclass) rather than in ``create`` guarantees the column is populated on
+        every path that persists a worker, including callers that build and commit a
+        worker without going through ``create``. A worker with no performance samples
+        therefore reports the same baseline throughput it did when speed was derived on
+        read.
+        """
+        super().__init__(**kwargs)
+        if self.speed is None:
+            self.speed = self._baseline_speed()
+
+    def _baseline_speed(self) -> float:
+        """Return the throughput a worker reports before it has any performance samples.
+
+        Mirrors the historical speed expression, which substituted one thing per second
+        (scaled into raw units by the worker type's divisor) whenever the performance
+        average was NULL, keeping fresh workers on the same side of the pop-filter
+        thresholds as when speed was derived on read.
+        """
+        return SPEED_BASELINE_THINGS_PER_SEC * hv.thing_divisors[self.wtype]
 
     def create(self, **kwargs):
         self.check_for_bad_actor()
@@ -395,6 +430,13 @@ class WorkerTemplate(db.Model):
             ).delete(synchronize_session=False)
         new_performance = WorkerPerformance(worker_id=self.id, performance=things_per_sec)
         db.session.add(new_performance)
+        # Refresh the materialized rolling average from the retained samples. The
+        # aggregate autoflushes the pending insert and the prune above, so it reflects
+        # exactly the rows a read-time subquery would have seen; recomputing from the
+        # samples (rather than incrementally) also makes this write self-healing if an
+        # earlier sample write was lost.
+        retained_average = db.session.query(func.avg(WorkerPerformance.performance)).filter_by(worker_id=self.id).scalar()
+        self.speed = retained_average if retained_average is not None else self._baseline_speed()
         if commit:
             db.session.commit()
 
@@ -554,10 +596,6 @@ class WorkerTemplate(db.Model):
             "online": not self.is_stale(),
         }
         return ret_dict
-
-
-# Don't know if this works, need to recreate the DB to find out
-# db.Index('ix_image_workers_speed', WorkerTemplate.speed)
 
 
 class Worker(WorkerTemplate):

--- a/horde/consts.py
+++ b/horde/consts.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-HORDE_VERSION = "5.0.3"
+HORDE_VERSION = "5.0.4"
 HORDE_API_VERSION = "2.5"
 
 WHITELISTED_SERVICE_IPS = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [project]
 name = "AI-Horde"
-version = "5.0.3"
+version = "5.0.4"
 description = "A Crowdsourced Generative AI cluster for everyone."
 authors = [
     {name = "db0", email = "mail@dbzer0.com"},

--- a/sql_statements/5.0.4-post.txt
+++ b/sql_statements/5.0.4-post.txt
@@ -1,0 +1,11 @@
+-- Removes the rollout scaffolding added by 5.0.4.txt.
+--
+-- Run only once no 5.0.3 instance remains in the fleet. A 5.0.3 worker registration
+-- omits the speed column, and once this trigger is gone that INSERT fails against the
+-- NOT NULL constraint. Until then the trigger is also what keeps a rollback to 5.0.3
+-- viable.
+
+SET lock_timeout = '3s';
+
+DROP TRIGGER IF EXISTS workers_speed_baseline_trg ON workers;
+DROP FUNCTION IF EXISTS workers_speed_baseline();

--- a/sql_statements/5.0.4-post.txt.license
+++ b/sql_statements/5.0.4-post.txt.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Tazlin <tazlin.on.github@gmail.com>
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/sql_statements/5.0.4.txt
+++ b/sql_statements/5.0.4.txt
@@ -1,0 +1,4 @@
+ALTER TABLE workers ADD COLUMN speed double precision;
+UPDATE workers w SET speed = COALESCE((SELECT avg(wp.performance) FROM worker_performances wp WHERE wp.worker_id = w.id), CASE WHEN w.worker_type IN ('stable_worker', 'worker') THEN 1000000 ELSE 1 END);
+ALTER TABLE workers ALTER COLUMN speed SET NOT NULL;
+CREATE INDEX ix_workers_speed ON public.workers USING btree (speed);

--- a/sql_statements/5.0.4.txt
+++ b/sql_statements/5.0.4.txt
@@ -1,4 +1,67 @@
+-- Run with psql in its default autocommit mode. Do NOT pass --single-transaction: this
+-- file contains CREATE INDEX CONCURRENTLY and VACUUM, neither of which can run inside a
+-- transaction block. Pass -v ON_ERROR_STOP=1 so a failure halts rather than continuing.
+--
+-- Safe to run against a fleet still on 5.0.3, and intended to be run before 5.0.4 is
+-- deployed. A 5.0.3 instance does not select the new column, so its reads are unaffected;
+-- its worker INSERT omits the column, which the trigger below covers.
+--
+-- The trigger is rollout scaffolding with a defined lifetime. It supplies the
+-- type-correct baseline for INSERTs that predate the application-side default, which is
+-- what allows the column to be NOT NULL from the outset and what keeps a rollback to
+-- 5.0.3 viable. sql_statements/5.0.4-post.txt removes it once no 5.0.3 instance remains.
+--
+-- A partial failure part-way through leaves the column present and nullable with the
+-- trigger installed, which 5.0.3 tolerates. Re-running requires dropping the column,
+-- trigger and function first.
+
+SET lock_timeout = '3s';
+
+-- worker_performances.worker_id carries a foreign key but no index, and PostgreSQL does
+-- not index foreign key columns automatically. The backfill below and every
+-- record_performance call filter by it, and scan the whole sample table without it.
+CREATE INDEX CONCURRENTLY ix_worker_performances_worker_id
+  ON public.worker_performances USING btree (worker_id);
+
 ALTER TABLE workers ADD COLUMN speed double precision;
-UPDATE workers w SET speed = COALESCE((SELECT avg(wp.performance) FROM worker_performances wp WHERE wp.worker_id = w.id), CASE WHEN w.worker_type IN ('stable_worker', 'worker') THEN 1000000 ELSE 1 END);
+
+CREATE FUNCTION workers_speed_baseline() RETURNS trigger AS $$
+BEGIN
+  IF NEW.speed IS NULL THEN
+    NEW.speed := CASE WHEN NEW.worker_type IN ('stable_worker', 'worker', 'worker_template')
+                      THEN 1000000 ELSE 1 END;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER workers_speed_baseline_trg BEFORE INSERT ON workers
+  FOR EACH ROW EXECUTE FUNCTION workers_speed_baseline();
+
+-- NULLIF mirrors the application fallback: a zero average is treated as no samples,
+-- because speed is a divisor in ProcessingGeneration.get_seconds_needed and a stored
+-- zero raises there.
+WITH avgs AS (
+  SELECT worker_id, NULLIF(avg(performance), 0) AS avg_perf
+  FROM worker_performances GROUP BY worker_id
+)
+UPDATE workers w
+SET speed = COALESCE(a.avg_perf,
+                     CASE WHEN w.worker_type IN ('stable_worker', 'worker', 'worker_template')
+                          THEN 1000000 ELSE 1 END)
+FROM workers w2
+LEFT JOIN avgs a ON a.worker_id = w2.id
+WHERE w.id = w2.id;
+
+-- The NOT VALID / VALIDATE pair lets SET NOT NULL skip its full table scan under
+-- ACCESS EXCLUSIVE (PostgreSQL 12+); VALIDATE itself takes only SHARE UPDATE EXCLUSIVE.
+ALTER TABLE workers ADD CONSTRAINT workers_speed_nn CHECK (speed IS NOT NULL) NOT VALID;
+ALTER TABLE workers VALIDATE CONSTRAINT workers_speed_nn;
 ALTER TABLE workers ALTER COLUMN speed SET NOT NULL;
-CREATE INDEX ix_workers_speed ON public.workers USING btree (speed);
+ALTER TABLE workers DROP CONSTRAINT workers_speed_nn;
+
+-- ANALYZE is required before the planner will use ix_workers_speed well; it has no
+-- statistics for a column this new.
+VACUUM (ANALYZE) workers;
+
+CREATE INDEX CONCURRENTLY ix_workers_speed ON public.workers USING btree (speed);

--- a/sql_statements/5.0.4.txt.license
+++ b/sql_statements/5.0.4.txt.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Tazlin <tazlin.on.github@gmail.com>
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/unit/test_worker_speed_materialization.py
+++ b/tests/unit/test_worker_speed_materialization.py
@@ -138,6 +138,38 @@ class TestRecordPerformanceMaintainsAverage:
         assert worker.speed == pytest.approx(sum(retained) / len(retained))
 
 
+class TestZeroAverageFallsBackToBaseline:
+    """Samples averaging zero leave ``speed`` at the baseline rather than storing zero.
+
+    ``speed`` is a divisor in ``ProcessingGeneration.get_seconds_needed``, so a stored
+    zero makes that reader raise. A worker whose retained samples average to zero is
+    therefore treated the same as one with no samples at all.
+    """
+
+    def test_zero_sample_leaves_speed_at_baseline(self, db_session, make_user):
+        worker = _make_text_worker(db_session, make_user(), name="speed_zero_sample")
+
+        worker.record_performance(0.0)
+
+        assert worker.speed == SPEED_BASELINE_THINGS_PER_SEC * hv.thing_divisors["text"]
+
+    def test_speed_stays_nonzero_for_division_by_reading_callers(self, db_session, make_user):
+        worker = _make_text_worker(db_session, make_user(), name="speed_zero_divisor")
+
+        worker.record_performance(0.0)
+
+        assert worker.speed != 0
+        assert 100 / worker.speed > 0
+
+    def test_nonzero_sample_after_zero_restores_the_average(self, db_session, make_user):
+        worker = _make_text_worker(db_session, make_user(), name="speed_zero_then_real")
+
+        worker.record_performance(0.0)
+        worker.record_performance(10.0)
+
+        assert worker.speed == pytest.approx(5.0)
+
+
 class TestSpeedReaders:
     """Readers that consume ``speed`` work in both the baseline and sampled states."""
 

--- a/tests/unit/test_worker_speed_materialization.py
+++ b/tests/unit/test_worker_speed_materialization.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin.on.github@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Behaviour of the materialized ``Worker.speed`` column.
+
+``speed`` stores each worker's rolling-average throughput (raw things per second)
+on the ``workers`` row. It is maintained by ``Worker.record_performance`` and
+seeded to a per-type baseline on construction so a worker that has never submitted
+a generation reports a stable speed rather than deriving one on read.
+
+The contracts exercised here are:
+
+- ``record_performance`` sets ``speed`` to the average of the retained performance
+  samples.
+- The pruning of ``worker_performances`` to the most recent samples is reflected in
+  ``speed``: dropped samples no longer influence the average.
+- A worker with no samples reports the per-type baseline, both when read as a Python
+  attribute and when compared inside a pop-candidate-filter-shaped query. The
+  baseline places image workers above, and text workers below, the speed thresholds
+  the pop filters apply.
+- Status and team readers that consume ``speed`` keep working across both states.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from horde import vars as hv
+from horde.classes.base.team import Team
+from horde.classes.base.worker import SPEED_BASELINE_THINGS_PER_SEC, WorkerPerformance, WorkerTemplate
+from horde.classes.kobold.worker import TextWorker
+from horde.classes.stable.worker import ImageWorker
+from horde.flask import db
+
+pytestmark = pytest.mark.unit
+
+# The lower speed bounds the image and text pop-candidate filters apply. Mirrored from
+# the production predicates (``horde/database/functions.py`` and
+# ``horde/database/text_functions.py``) so the tests assert the same inclusion boundary
+# a pop evaluates against the materialized column.
+IMAGE_POP_SPEED_THRESHOLD = 500000
+TEXT_POP_SPEED_THRESHOLD = 2
+
+
+def _make_image_worker(db_session: Any, user: Any, *, name: str) -> ImageWorker:
+    worker = ImageWorker(user_id=user.id, name=name)
+    db_session.add(worker)
+    db_session.commit()
+    return worker
+
+
+def _make_text_worker(db_session: Any, user: Any, *, name: str) -> TextWorker:
+    worker = TextWorker(user_id=user.id, name=name)
+    db_session.add(worker)
+    db_session.commit()
+    return worker
+
+
+def _retained_performances(worker_id: Any) -> list[float]:
+    rows = db.session.query(WorkerPerformance.performance).filter_by(worker_id=worker_id).all()
+    return [row.performance for row in rows]
+
+
+class TestBaselineSpeedWithoutSamples:
+    """A worker with no performance samples reports the per-type baseline speed."""
+
+    def test_fresh_image_worker_reports_image_baseline(self, db_session, make_user):
+        worker = _make_image_worker(db_session, make_user(), name="speed_fresh_image")
+
+        assert worker.speed == SPEED_BASELINE_THINGS_PER_SEC * hv.thing_divisors["image"]
+
+    def test_fresh_text_worker_reports_text_baseline(self, db_session, make_user):
+        worker = _make_text_worker(db_session, make_user(), name="speed_fresh_text")
+
+        assert worker.speed == SPEED_BASELINE_THINGS_PER_SEC * hv.thing_divisors["text"]
+
+
+class TestBaselineSpeedAgainstPopFilter:
+    """Baseline speed keeps fresh workers on the pop filter's expected side.
+
+    The pop candidate filters compare ``speed`` against a per-type threshold. A fresh
+    image worker's baseline clears the image threshold (so it can be offered work
+    immediately), while a fresh text worker's baseline falls below the text threshold
+    (so it is treated as a slow worker until it records real samples).
+    """
+
+    def test_fresh_image_worker_passes_image_speed_filter(self, db_session, make_user):
+        worker = _make_image_worker(db_session, make_user(), name="speed_filter_image")
+
+        matched = (
+            db.session.query(WorkerTemplate.id)
+            .filter(WorkerTemplate.id == worker.id, WorkerTemplate.speed >= IMAGE_POP_SPEED_THRESHOLD)
+            .first()
+        )
+
+        assert matched is not None
+
+    def test_fresh_text_worker_excluded_by_text_speed_filter(self, db_session, make_user):
+        worker = _make_text_worker(db_session, make_user(), name="speed_filter_text")
+
+        matched = (
+            db.session.query(WorkerTemplate.id)
+            .filter(WorkerTemplate.id == worker.id, WorkerTemplate.speed >= TEXT_POP_SPEED_THRESHOLD)
+            .first()
+        )
+
+        assert matched is None
+
+
+class TestRecordPerformanceMaintainsAverage:
+    """``record_performance`` keeps ``speed`` equal to the average of retained samples."""
+
+    def test_speed_tracks_running_average(self, db_session, make_user):
+        worker = _make_image_worker(db_session, make_user(), name="speed_running_avg")
+
+        worker.record_performance(100.0)
+        assert worker.speed == pytest.approx(100.0)
+
+        worker.record_performance(200.0)
+        assert worker.speed == pytest.approx(150.0)
+
+    def test_speed_reflects_only_retained_samples_after_pruning(self, db_session, make_user, frozen_time):
+        worker = _make_image_worker(db_session, make_user(), name="speed_pruned_avg")
+        recorded_values = [float(i) for i in range(1, 26)]
+
+        with frozen_time("2026-01-01 00:00:00") as frozen:
+            for value in recorded_values:
+                worker.record_performance(value)
+                frozen.tick(timedelta(seconds=1))
+
+        retained = _retained_performances(worker.id)
+        assert len(retained) < len(recorded_values)
+        assert min(retained) > recorded_values[0]
+        assert worker.speed == pytest.approx(sum(retained) / len(retained))
+
+
+class TestSpeedReaders:
+    """Readers that consume ``speed`` work in both the baseline and sampled states."""
+
+    def test_worker_performance_string_uses_speed(self, db_session, make_user):
+        worker = _make_image_worker(db_session, make_user(), name="speed_reader_worker")
+
+        baseline_description = worker.get_performance()
+        assert "per second" in baseline_description
+
+        worker.record_performance(250000.0)
+        assert worker.get_performance() != baseline_description
+
+    def test_team_performance_reads_member_speed(self, db_session, make_user):
+        user = make_user()
+        team = Team(name="speed_reader_team", owner_id=user.id)
+        db_session.add(team)
+        db_session.commit()
+        worker = _make_image_worker(db_session, user, name="speed_team_member")
+        worker.team_id = team.id
+        db_session.commit()
+
+        perf_avg, perf_total = team.get_performance()
+
+        expected = round(worker.speed / hv.thing_divisors["image"], 1)
+        assert perf_total == expected
+        assert perf_avg == expected

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12, <3.14"
 
 [[package]]
 name = "ai-horde"
-version = "5.0.3"
+version = "5.0.4"
 source = { virtual = "." }
 dependencies = [
     { name = "alt-profanity-check" },


### PR DESCRIPTION
`Worker.speed` was a hybrid property whose SQL form ran a correlated `avg(worker_performances)` subquery per candidate worker per pop. By cumulative execution time this was the database's single largest query (on the order of billions of executions in a 13-month `pg_stat_statements` window on production). This PR replaces it with a plain NOT-NULL `speed` column maintained at the one write site. Every existing `worker.speed >= N` filter and Python reader keeps working unchanged; it now resolves to an indexed column read instead of a correlated subquery.

Pop-filter classification is preserved exactly, verified against a production copy. The one deliberate semantic change is zero-average handling, which follows the old Python getter rather than the old SQL expression; see below for why the two disagreed and why the Python form is the one that must survive.

The PR also indexes `worker_performances.worker_id`, which carried a foreign key but no index. Without it the new maintenance path would trade a read-side scan for a write-side one on every job completion.

## Fix

- The hybrid property is replaced by a column (`worker.py:201`, at bottom of excerpt): https://github.com/Haidra-Org/AI-Horde/blob/97ccd9b1bb1b6bcedee8c85eed39a5a6cbdb394a/horde/classes/base/worker.py#L177-L201
- Maintained in `record_performance`, the only site that mutates performance samples: after pruning old samples and inserting the new one, the retained average is recomputed and written to `speed` (`worker.py:451-453`). https://github.com/Haidra-Org/AI-Horde/blob/97ccd9b1bb1b6bcedee8c85eed39a5a6cbdb394a/horde/classes/base/worker.py#L451-L453
- Seeded in `__init__` (the single construction chokepoint) rather than only in `create()`, so every path that persists a worker satisfies the NOT-NULL constraint (`worker.py:191-216`). https://github.com/Haidra-Org/AI-Horde/blob/97ccd9b1bb1b6bcedee8c85eed39a5a6cbdb394a/horde/classes/base/worker.py#L191-L216
- `WorkerPerformance.worker_id` gains an index (`worker.py:48-58`). It carries a foreign key but no index, and PostgreSQL does not index foreign key columns automatically. `record_performance` filters this table by `worker_id` twice per completed job (the prune and the new average), so without it the write path pays a sequential scan of the full sample table on every job completion. `worker_performances` has 135,724 rows at present in production.

### Pop-filter behavior is preserved

The old SQL expression was `COALESCE(avg(...), baseline)` with a per-type CASE baseline. A worker with no samples reports the per-type baseline `1 * thing_divisors[wtype]`, which reproduces the old behavior at the pop thresholds: fresh image workers still clear the `>= 500000` pop filter, fresh text and interrogation workers still fall below theirs. The tests pin this in both shapes (Python attribute read and a pop-filter-shaped SQL query with the production thresholds mirrored in).

### Zero-average handling

The old property had two forms that disagreed. The SQL expression fell back to the baseline only on a NULL average; the Python getter used a truthiness check (`if performance_avg:`) and so fell back on a zero average too. This dynamic did some heavy lifting as `speed` is a divisor in `ProcessingGeneration.get_seconds_needed` (`self.wp.things / self.worker.speed`), and only the Python form reached that division. Materializing the SQL form verbatim would store a zero and raise `ZeroDivisionError` there.

The column therefore preserves the Python semantics: a zero average falls back to the baseline, in `record_performance` (`retained_average if retained_average else ...`) and in the migration's backfill (`NULLIF(avg(performance), 0)`). The substitution is invisible to every pop filter, since zero and the baseline fall on the same side of all four thresholds (`>= 500000`, `>= 2`, `>= slow_speed` where `slow_speed` is 3 to 5, and `< 10`).

Production carries exactly one affected row today, a `text_worker` whose retained samples average to zero. It fails `>= 2` either way.

### Migration

The backfill uses a single hash aggregate rather than a correlated subquery per row. Measured on production it took over 90 seconds for 17,655 workers against the unindexed `worker_performances.worker_id`.

```sql
WITH avgs AS (
  SELECT worker_id, NULLIF(avg(performance), 0) AS avg_perf
  FROM worker_performances GROUP BY worker_id
)
UPDATE workers w
SET speed = COALESCE(a.avg_perf,
                     CASE WHEN w.worker_type IN ('stable_worker', 'worker', 'worker_template')
                          THEN 1000000 ELSE 1 END)
FROM workers w2
LEFT JOIN avgs a ON a.worker_id = w2.id
WHERE w.id = w2.id;
```

`worker_template` is included in the CASE because it is a live polymorphic identity whose `wtype` is `image`; the original expression's `ELSE 1` would have mispriced any such row. Production currently has none.

The full file also creates both indexes with `CREATE INDEX CONCURRENTLY`, uses the `CHECK ... NOT VALID` / `VALIDATE` / `SET NOT NULL` sequence so the constraint skips its full-table scan under `ACCESS EXCLUSIVE`, sets `lock_timeout` so a contended `ALTER` aborts rather than stalling the fleet, and runs `VACUUM (ANALYZE)` so the planner has statistics for the new column.

Staleness window: `speed` changes only when `record_performance` runs, same as before (the subquery read the same `worker_performances` rows the same site maintains). Within a single application version there is no drift source; the column and the sample table have a single common writer. The one exception is the mixed-version rollout window, covered below.

## Deployment: migration must land before the code

The rollout of AI-Horde versions is progressive, so both versions run against one database for a short time. This means that there is a possibility of 500s mid-rollout. This is due to the new column being non-nullable and there being subtle INSERT differences across the 5.0.3 and 5.0.4 boundary.

To avoid mid-deployment 500s, `5.0.4.txt` installs a `BEFORE INSERT` trigger supplying the type-correct baseline. This is just to get through AI-Horde deployment cleanly. `sql_statements/5.0.4-post.txt` drops the trigger once no previous-version instance remains. However, this also gives us a code rollback safe out in case of issues, since it is the only thing keeping the older version's registrations working against the migrated schema.

Order of operations:

1. Migrate (`5.0.4.txt`), against the fleet still running the previous version.
2. Verify the fleet is unaffected and worker registration still succeeds.
3. Deploy 5.0.4.
4. Verify no worker was stranded at the wrong baseline.
5. Drop the trigger (`5.0.4-post.txt`) once the fleet is uniform.

During step 3, an instance on the previous version writes performance samples without updating `speed`, so that worker's value goes stale. It corrects on the first `record_performance` served by a 5.0.4 instance, which recomputes from the retained samples rather than incrementing. Drift is bounded by rollout duration and self-heals.

## Test plan

`tests/unit/test_worker_speed_materialization.py` (198 lines, 11 tests) pins:

- `record_performance` sets `speed` to the average of retained samples, including the prune interaction (a pruned sample stops contributing).
- Baseline behavior with no samples, both as a Python read and inside a pop-candidate-filter-shaped query at the production thresholds.
- A zero average falls back to the baseline, the stored value stays usable as a divisor, and a later real sample still averages correctly.
- Status/team readers (`get_performance()`, `Team.get_performance()`) across both states.

Full suite on this branch: 295 passed (unit + integration).

Migration semantics were rehearsed against a production copy inside a rolled-back transaction. The backfill plans as a `HashAggregate` and completes in 763ms for 17,655 workers over 135,724 samples. Pop-filter classification after the backfill matches the pre-migration expression exactly (6,398 image workers above `>= 500000`, unchanged), and no row lands NULL or zero.

## Validation / reproduction

Confirm on the live database by comparing `pg_stat_statements` entries for the pop candidate query before and after: the `avg(worker_performances)` scalar subquery disappears from the plan and the pop query's mean time drops accordingly.

Further, to verify the migration preserved behavior, I will capture the following before migrating and compare it against the same counts read from the column afterward. I expect them to match once the migration is complete.

```sql
-- after migration
SELECT
  count(*) FILTER (WHERE worker_type IN ('stable_worker','worker','worker_template') AND speed >= 500000) AS image_pop,
  count(*) FILTER (WHERE worker_type = 'text_worker' AND speed >= 2) AS text_pop,
  count(*) FILTER (WHERE worker_type = 'interrogation_worker' AND speed < 10) AS interrogation_pop
FROM workers;
```