### PR TITLE
Characterize kudos semantics ahead of the kudos ledger rework

### DIFF
--- a/horde/classes/base/processing_generation.py
+++ b/horde/classes/base/processing_generation.py
@@ -196,13 +196,7 @@ class ProcessingGeneration(db.Model):
         lock_user_ids = {self.worker.user_id, self.wp.user_id}
         lock_user_ids.discard(None)
         if len(lock_user_ids) > 1:
-            (
-                db.session.query(User.id)
-                .filter(User.id.in_(lock_user_ids))
-                .order_by(User.id.asc())
-                .with_for_update(key_share=True)
-                .all()
-            )
+            (db.session.query(User.id).filter(User.id.in_(lock_user_ids)).order_by(User.id.asc()).with_for_update(key_share=True).all())
 
         cancel_txt = ""
         if self.cancelled:

--- a/horde/classes/base/waiting_prompt.py
+++ b/horde/classes/base/waiting_prompt.py
@@ -226,18 +226,15 @@ class WaitingPrompt(db.Model):
                 db.session.rollback()
                 if attempt == WP_ACTIVATE_DEADLOCK_RETRIES - 1:
                     logger.error(
-                        f"Deadlock activating WP {self.id}; retries exhausted "
-                        f"({WP_ACTIVATE_DEADLOCK_RETRIES} attempts)",
+                        f"Deadlock activating WP {self.id}; retries exhausted ({WP_ACTIVATE_DEADLOCK_RETRIES} attempts)",
                     )
                     raise
                 logger.warning(
-                    f"Deadlock activating WP {self.id}; retrying "
-                    f"(attempt {attempt + 1}/{WP_ACTIVATE_DEADLOCK_RETRIES})",
+                    f"Deadlock activating WP {self.id}; retrying (attempt {attempt + 1}/{WP_ACTIVATE_DEADLOCK_RETRIES})",
                 )
                 # Small jittered backoff so racing transactions re-attempt out of
                 # phase instead of colliding on the same rows again immediately.
                 time.sleep(random.uniform(0.005, 0.03) * (attempt + 1))
-
 
     def _activate(self, downgrade_wp_priority=False, extra_source_images=None, kudos_adjustment=0):
         """We separate the activation from __init__ as often we want to check if there's a valid worker for it
@@ -339,8 +336,7 @@ class WaitingPrompt(db.Model):
                 from horde.classes.base.worker import WorkerModel
 
                 declared_models = [
-                    row.model
-                    for row in db.session.query(WorkerModel.model).filter(WorkerModel.worker_id == worker.id).all()
+                    row.model for row in db.session.query(WorkerModel.model).filter(WorkerModel.worker_id == worker.id).all()
                 ]
         wp_models = list(self.get_model_names())
         if len(wp_models) != 0:

--- a/horde/classes/base/worker.py
+++ b/horde/classes/base/worker.py
@@ -432,10 +432,7 @@ class WorkerTemplate(db.Model):
         if performances.count() >= 20:
             # Keep only the 20 most recent performance records
             keep_ids = (
-                db.session.query(WorkerPerformance.id)
-                .filter_by(worker_id=self.id)
-                .order_by(WorkerPerformance.created.desc())
-                .limit(20)
+                db.session.query(WorkerPerformance.id).filter_by(worker_id=self.id).order_by(WorkerPerformance.created.desc()).limit(20)
             )
             db.session.query(WorkerPerformance).filter_by(worker_id=self.id).filter(
                 WorkerPerformance.id.not_in(keep_ids),

--- a/horde/classes/kobold/genstats.py
+++ b/horde/classes/kobold/genstats.py
@@ -82,8 +82,7 @@ def get_compiled_textgen_stats_totals() -> dict[str, dict[str, int]]:
             stats_dict[period]["tokens"] = getattr(query, f"{period}_tokens")
     else:
         logger.warning(
-            "No compiled text generation totals found; returning zeros. "
-            "Is the 'compile_textgen_stats_totals' pg_cron job running?",
+            "No compiled text generation totals found; returning zeros. Is the 'compile_textgen_stats_totals' pg_cron job running?",
         )
 
     return stats_dict

--- a/horde/classes/kobold/processing_generation.py
+++ b/horde/classes/kobold/processing_generation.py
@@ -99,10 +99,7 @@ class TextProcessingGeneration(ProcessingGeneration):
         # Also inject a csam metadata entry when state == "csam" so the
         # authoritative source (gen_metadata) is always consistent.
         gen_metadata = list(kwargs.get("gen_metadata", self.gen_metadata or []))
-        has_csam_meta = any(
-            isinstance(m, dict) and m.get("type") == "censorship" and m.get("value") == "csam"
-            for m in gen_metadata
-        )
+        has_csam_meta = any(isinstance(m, dict) and m.get("type") == "censorship" and m.get("value") == "csam" for m in gen_metadata)
         if not has_csam_meta and state == "csam":
             gen_metadata.append({"type": "censorship", "value": "csam"})
             kwargs = {**kwargs, "gen_metadata": gen_metadata}

--- a/horde/classes/kobold/worker.py
+++ b/horde/classes/kobold/worker.py
@@ -65,10 +65,7 @@ class TextWorker(Worker):
         # the self.softprompts relationship collection. Under expire_on_commit=False that
         # collection can remain loaded with pre-change rows across a commit, which would
         # republish a stale list. A direct query always reflects what was written.
-        softprompts_list = [
-            row.softprompt
-            for row in db.session.query(TextWorkerSoftprompts.softprompt).filter_by(worker_id=self.id).all()
-        ]
+        softprompts_list = [row.softprompt for row in db.session.query(TextWorkerSoftprompts.softprompt).filter_by(worker_id=self.id).all()]
         try:
             hr.horde_r_setex(
                 f"worker_{self.id}_softprompts_cache",

--- a/horde/classes/stable/genstats.py
+++ b/horde/classes/stable/genstats.py
@@ -201,8 +201,7 @@ def get_compiled_imagegen_stats_totals() -> dict[str, dict[str, int]]:
             stats[period]["ps"] = getattr(latest_entry, f"{period}_pixels")
     else:
         logger.warning(
-            "No compiled image generation totals found; returning zeros. "
-            "Is the 'compile_imagegen_stats_totals' pg_cron job running?",
+            "No compiled image generation totals found; returning zeros. Is the 'compile_imagegen_stats_totals' pg_cron job running?",
         )
 
     return stats

--- a/horde/classes/stable/interrogation_worker.py
+++ b/horde/classes/stable/interrogation_worker.py
@@ -91,10 +91,7 @@ class InterrogationWorker(WorkerTemplate):
         if performances.count() >= 20:
             # Keep only the 20 most recent performance records
             keep_ids = (
-                db.session.query(WorkerPerformance.id)
-                .filter_by(worker_id=self.id)
-                .order_by(WorkerPerformance.created.desc())
-                .limit(20)
+                db.session.query(WorkerPerformance.id).filter_by(worker_id=self.id).order_by(WorkerPerformance.created.desc()).limit(20)
             )
             db.session.query(WorkerPerformance).filter_by(worker_id=self.id).filter(
                 WorkerPerformance.id.not_in(keep_ids),

--- a/horde/database/threads.py
+++ b/horde/database/threads.py
@@ -530,10 +530,7 @@ def increment_extra_priority():
                 )
                 if last_id is not None:
                     id_query = id_query.filter(wp_class.id > last_id)
-                locked_ids = [
-                    row.id
-                    for row in id_query.order_by(wp_class.id.asc()).limit(chunk_size).with_for_update(skip_locked=True)
-                ]
+                locked_ids = [row.id for row in id_query.order_by(wp_class.id.asc()).limit(chunk_size).with_for_update(skip_locked=True)]
                 if not locked_ids:
                     break
                 last_id = locked_ids[-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dev = [
     "reuse",
     "pre-commit",
     "locust>=2.43.4",
+    "types-python-dateutil>=2.9.0.20260716",
 ]
 # Optional runtime group used by the Dockerfile's AI_HORDE_DEPENDENCY_GROUPS
 # build arg. Keep profiler wheels out of the default image; publish/use the
@@ -162,6 +163,7 @@ output = "coverage.xml"
 # Permissive baseline so existing untyped modules don't block adoption.
 # Files explicitly listed under [[tool.mypy.overrides]] with strict = true
 # form the "typed allowlist".
+plugins = ["sqlalchemy.ext.mypy.plugin"]
 python_version = "3.12"
 ignore_missing_imports = true
 follow_imports = "silent"

--- a/tests/fixture_types.py
+++ b/tests/fixture_types.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2026 Tazlin
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Shared typing helpers for the test-suite fixtures.
+
+Provides call-signature Protocols for the object-factory fixtures so consuming
+tests can annotate the injected factories precisely instead of falling back to
+``Callable[..., ...]``. The legacy ORM models (``User``, ``UserRole``) are
+untyped, so factory keyword overrides are honestly typed as ``Any``.
+
+Public members:
+    ApiUser: Immutable view of a registered user returned by ``make_api_user``.
+    MakeUser: Call signature of the ``make_user`` fixture factory.
+    MakeUserRole: Call signature of the ``make_user_role`` fixture factory.
+    MakeApiUser: Call signature of the ``make_api_user`` fixture factory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from horde.classes.base.user import User, UserRole
+    from horde.enums import UserRoleTypes
+
+__all__ = [
+    "ApiUser",
+    "MakeApiUser",
+    "MakeUser",
+    "MakeUserRole",
+]
+
+
+@dataclass(frozen=True)
+class ApiUser:
+    """Represents the registered user created by the ``make_api_user`` factory.
+
+    Carries only the fields endpoint tests need to act as the user: its database
+    id, plaintext API key, username, and unique alias. Immutable because every
+    consumer treats it as a read-only handle.
+    """
+
+    id: int
+    api_key: str
+    username: str
+    alias: str
+
+
+class MakeUser(Protocol):
+    """Call signature of the ``make_user`` fixture factory."""
+
+    def __call__(self, **overrides: Any) -> User:
+        """Build and persist a ``User``, applying column keyword overrides."""
+        ...
+
+
+class MakeUserRole(Protocol):
+    """Call signature of the ``make_user_role`` fixture factory."""
+
+    def __call__(self, user: User, role_type: UserRoleTypes, *, value: bool = True) -> UserRole:
+        """Attach a ``UserRole`` of ``role_type`` to ``user``."""
+        ...
+
+
+class MakeApiUser(Protocol):
+    """Call signature of the ``make_api_user`` fixture factory."""
+
+    def __call__(self, *, trusted: bool = False, moderator: bool = False, kudos: int = 0) -> ApiUser:
+        """Create a registered user at the requested privilege and kudos level."""
+        ...

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,11 +6,17 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 import pytest
 import sqlalchemy
 
 from tests.dependency_runtime import create_schema, drop_schema, new_test_schema_name, postgres_reachable
+from tests.fixture_types import ApiUser, MakeApiUser
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from flask.testing import FlaskClient
 
 TEST_USER_BOOTSTRAP_PAYLOAD = {
     "username": "test_user",
@@ -66,7 +72,7 @@ def _pg_schema(pg_dsn: str) -> Iterator[str]:
 
 
 @pytest.fixture(scope="module")
-def app(pg_dsn: str, _pg_schema: str):
+def app(pg_dsn: str, _pg_schema: str) -> Iterator[Flask]:
     from horde.flask import create_app, db
 
     app = create_app(
@@ -164,7 +170,7 @@ def _reset_redis_state() -> None:
 
 
 @pytest.fixture
-def client(app):
+def client(app: Flask) -> FlaskClient:
     return app.test_client()
 
 
@@ -177,7 +183,7 @@ def request_headers(api_key: str, CIVERSION: str) -> dict[str, str]:
 
 
 @pytest.fixture
-def make_api_user(app):
+def make_api_user(app: Flask) -> MakeApiUser:
     """Factory: create a registered user and return its id/api_key/username/alias.
 
     Used by endpoint tests that need actors at specific privilege levels (a
@@ -185,17 +191,20 @@ def make_api_user(app):
     moderator+trusted ``api_key`` fixture user.
     """
     import uuid
-    from types import SimpleNamespace
 
     from horde.classes.base.user import User
     from horde.utils import generate_api_key, hash_api_key
 
-    def _make(*, trusted: bool = False, moderator: bool = False, kudos: int = 0):
+    def _make(*, trusted: bool = False, moderator: bool = False, kudos: int = 0) -> ApiUser:
         suffix = uuid.uuid4().hex[:8]
         username = f"user_{suffix}"
         raw_api_key = generate_api_key()
         with app.app_context():
-            user = User(username=username, oauth_id=f"oauth_{suffix}", api_key=hash_api_key(raw_api_key))
+            user = User(
+                username=username,
+                oauth_id=f"oauth_{suffix}",
+                api_key=hash_api_key(raw_api_key),
+            )
             user.create()
             if moderator:
                 user.set_moderator(True)
@@ -204,7 +213,7 @@ def make_api_user(app):
             if kudos:
                 user.modify_kudos(kudos, "admin")
             user.refresh_cache()
-            return SimpleNamespace(
+            return ApiUser(
                 id=user.id,
                 api_key=raw_api_key,
                 username=username,
@@ -215,7 +224,7 @@ def make_api_user(app):
 
 
 @pytest.fixture
-def api_key(app) -> str:
+def api_key(app: Flask) -> str:
     """Create or refresh the integration test user and return a plaintext API key."""
     from horde.classes.base.user import User
     from horde.database import functions as database

--- a/tests/integration/test_kudos_aesthetics.py
+++ b/tests/integration/test_kudos_aesthetics.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin@haidra.net>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Endpoint characterization for the aesthetics rating reward.
+
+Rating the images of a completed, publicly shared request awards the requester
+kudos: five per rating. The award can never exceed what the request cost, so it
+is capped at the request's consumed kudos minus one.
+
+This drives the real ``/generate/rate`` endpoint. The rating relay to the
+external ratings service is outside this suite's contract and is stubbed to
+succeed so the kudos award is observed deterministically.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from tests.fixture_types import MakeApiUser
+
+AGENT: str = "aihorde_ci_client:1.0:(test)ci"
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limit() -> Iterator[None]:
+    """Disable the rate limiter for the duration of a test."""
+    from horde.limiter import limiter
+
+    previous = limiter.enabled
+    limiter.enabled = False
+    yield
+    limiter.enabled = previous
+
+
+@pytest.fixture
+def _stub_ratings_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the outbound relay to the external ratings service to always succeed."""
+    import horde.apis.v2.stable as stable_module
+
+    monkeypatch.setattr(stable_module.requests, "post", lambda *a, **k: SimpleNamespace(ok=True, status_code=200))
+
+
+def _build_completed_shared_wp(app: Flask, requester_id: int, *, consumed_kudos: int) -> tuple[str, str]:
+    """Create a completed, publicly shared waiting prompt and return its id and generation id."""
+    from horde.classes.stable.processing_generation import ImageProcessingGeneration
+    from horde.classes.stable.waiting_prompt import ImageWaitingPrompt
+    from horde.classes.stable.worker import ImageWorker
+    from horde.flask import db
+
+    with app.app_context():
+        worker = ImageWorker(name=f"worker_{uuid.uuid4().hex[:8]}", user_id=requester_id)
+        db.session.add(worker)
+        db.session.commit()
+
+        wp = ImageWaitingPrompt(
+            worker_ids=[],
+            models=["stable_diffusion"],
+            prompt="a shared test robot",
+            user_id=requester_id,
+            params={"width": 512, "height": 512, "steps": 8, "sampler_name": "k_euler_a", "n": 1},
+        )
+        wp.shared = True
+        wp.n = 0
+        wp.consumed_kudos = consumed_kudos
+        db.session.commit()
+
+        procgen = ImageProcessingGeneration(wp_id=wp.id, worker_id=worker.id, model="stable_diffusion")
+        procgen.generation = "R2"
+        procgen.seed = 0
+        db.session.commit()
+        return str(wp.id), str(procgen.id)
+
+
+def _requester_kudos(app: Flask, user_id: int) -> float:
+    """Return the committed kudos balance for the user with the given id."""
+    from horde.database import functions as database
+
+    with app.app_context():
+        return database.find_user_by_id(user_id).kudos
+
+
+class TestAestheticsReward:
+    """Rating a completed, publicly shared request's images awards the requester kudos."""
+
+    def test_reward_is_five_kudos_per_rating(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        make_api_user: MakeApiUser,
+        _stub_ratings_server: None,
+    ) -> None:
+        """Each rating submitted for a shared request awards the requester five kudos."""
+        requester = make_api_user(kudos=1000)
+        wp_id, procgen_id = _build_completed_shared_wp(app, requester.id, consumed_kudos=100)
+        before = _requester_kudos(app, requester.id)
+
+        resp = client.post(
+            f"/api/v2/generate/rate/{wp_id}",
+            json={"ratings": [{"id": procgen_id, "rating": 8}]},
+            headers={"Client-Agent": AGENT},
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert resp.get_json()["reward"] == 5
+        assert _requester_kudos(app, requester.id) == before + 5
+
+    def test_reward_is_capped_at_consumed_kudos_minus_one(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        make_api_user: MakeApiUser,
+        _stub_ratings_server: None,
+    ) -> None:
+        """The rating reward is capped at the request's consumed kudos minus one."""
+        requester = make_api_user(kudos=1000)
+        # One rating would award 5, but the request only consumed 3 kudos.
+        wp_id, procgen_id = _build_completed_shared_wp(app, requester.id, consumed_kudos=3)
+        before = _requester_kudos(app, requester.id)
+
+        resp = client.post(
+            f"/api/v2/generate/rate/{wp_id}",
+            json={"ratings": [{"id": procgen_id, "rating": 8}]},
+            headers={"Client-Agent": AGENT},
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert resp.get_json()["reward"] == 2
+        assert _requester_kudos(app, requester.id) == before + 2

--- a/tests/integration/test_kudos_endpoints.py
+++ b/tests/integration/test_kudos_endpoints.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin@haidra.net>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Endpoint characterization for the kudos gift, award, and admin flows.
+
+Exercises the HTTP surface that moves kudos between accounts: the user-to-user
+transfer (with its audit log and shared-key crediting), the privileged award,
+and the admin adjustment of balance and monthly entitlement. Mutations are
+verified against committed database state via the ORM rather than echoing the
+response back to itself. Also guards that the unreachable Kobold transfer
+resource stays unregistered.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timedelta
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from tests.fixture_types import MakeApiUser
+
+AGENT: str = "aihorde_ci_client:1.0:(test)ci"
+ANON_API_KEY: str = "0000000000"
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limit() -> Iterator[None]:
+    """Disable the rate limiter for the duration of a test."""
+    from horde.limiter import limiter
+
+    previous = limiter.enabled
+    limiter.enabled = False
+    yield
+    limiter.enabled = previous
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    """Return request headers carrying the given API key and the test client agent."""
+    return {"apikey": api_key, "Client-Agent": AGENT}
+
+
+def _user_kudos(app: Flask, user_id: int) -> float:
+    """Return the committed kudos balance for the user with the given id."""
+    from horde.database import functions as database
+
+    with app.app_context():
+        return database.find_user_by_id(user_id).kudos
+
+
+class TestKudosTransferAudit:
+    """A user-to-user kudos transfer records its movement and rejects anonymous senders."""
+
+    def test_successful_transfer_writes_an_audit_log_row(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        api_key: str,
+        make_api_user: MakeApiUser,
+    ) -> None:
+        """A successful transfer writes an audit-log row capturing the sender, receiver, and amount."""
+        from horde.classes.base.user import KudosTransferLog
+        from horde.database import functions as database
+
+        with app.app_context():
+            sender_id = database.find_user_by_api_key(api_key).id
+        receiver = make_api_user(kudos=100)
+
+        resp = client.post(
+            "/api/v2/kudos/transfer",
+            json={"username": receiver.alias, "amount": 500},
+            headers=_headers(api_key),
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+
+        with app.app_context():
+            log = KudosTransferLog.query.filter_by(source_id=sender_id, dest_id=receiver.id).first()
+            assert log is not None
+            assert log.kudos == 500
+
+    def test_transfer_from_anonymous_is_rejected(
+        self,
+        client: FlaskClient,
+        make_api_user: MakeApiUser,
+    ) -> None:
+        """The anonymous user cannot transfer kudos to another account."""
+        receiver = make_api_user(kudos=100)
+        resp = client.post(
+            "/api/v2/kudos/transfer",
+            json={"username": receiver.alias, "amount": 100},
+            headers=_headers(ANON_API_KEY),
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["rc"] == "KudosTransferFromAnon"
+
+
+class TestKudosTransferToSharedKey:
+    """A kudos transfer addressed to a shared key credits that key's budget."""
+
+    def test_transfer_to_shared_key_credits_the_key_budget(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        api_key: str,
+        make_api_user: MakeApiUser,
+    ) -> None:
+        """Transferring to a shared key id credits the key's budget by the transferred amount."""
+        from horde.classes.base.user import UserSharedKey
+        from horde.flask import db
+
+        receiver = make_api_user(kudos=100)
+        with app.app_context():
+            # Legacy declarative models expose untyped implicit constructors.
+            shared_key = UserSharedKey(
+                id=uuid.uuid4(),
+                user_id=receiver.id,
+                kudos=5000,
+                expiry=datetime.utcnow() + timedelta(days=1),
+                name="test-shared-key",
+            )
+            db.session.add(shared_key)
+            db.session.commit()
+            shared_key_id = str(shared_key.id)
+
+        resp = client.post(
+            "/api/v2/kudos/transfer",
+            json={"username": shared_key_id, "amount": 500},
+            headers=_headers(api_key),
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+
+        with app.app_context():
+            refreshed = db.session.get(UserSharedKey, uuid.UUID(shared_key_id))
+            assert refreshed is not None
+            assert refreshed.kudos == 5500
+
+
+def _provision_privileged_user(app: Flask) -> str:
+    """Return a plaintext API key for the sole award-privileged account (id 1)."""
+    from horde.classes.base.user import User
+    from horde.database import functions as database
+    from horde.flask import db
+    from horde.utils import generate_api_key, hash_api_key
+
+    raw_api_key = generate_api_key()
+    with app.app_context():
+        privileged = database.find_user_by_id(1)
+        if privileged is None:
+            privileged = User(id=1, username="privileged_one", oauth_id="priv_one", api_key=hash_api_key(raw_api_key))
+            privileged.create()
+        else:
+            privileged.api_key = hash_api_key(raw_api_key)
+            db.session.commit()
+    return raw_api_key
+
+
+class TestKudosAward:
+    """The privileged award endpoint credits a target only when called by the award-privileged account."""
+
+    def test_award_rejects_non_privileged_caller(
+        self,
+        client: FlaskClient,
+        make_api_user: MakeApiUser,
+    ) -> None:
+        """A caller without award privilege is forbidden from awarding kudos."""
+        actor = make_api_user(kudos=100)
+        target = make_api_user(kudos=0)
+        resp = client.post(
+            "/api/v2/kudos/award",
+            json={"username": target.alias, "amount": 5000},
+            headers=_headers(actor.api_key),
+        )
+        assert resp.status_code == 403
+        assert resp.get_json()["rc"] == "NotAllowedAwards"
+
+    def test_privileged_caller_credits_target(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        make_api_user: MakeApiUser,
+    ) -> None:
+        """The award-privileged caller credits the target's balance by the awarded amount."""
+        privileged_key = _provision_privileged_user(app)
+        target = make_api_user(kudos=0)
+        target_before = _user_kudos(app, target.id)
+
+        resp = client.post(
+            "/api/v2/kudos/award",
+            json={"username": target.alias, "amount": 5000},
+            headers=_headers(privileged_key),
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert resp.get_json()["awarded"] == 5000
+        assert _user_kudos(app, target.id) == target_before + 5000
+
+
+class TestAdminKudosAdjust:
+    """An admin editing a user credits balance directly and grants monthly entitlement immediately."""
+
+    def test_admin_kudos_delta_credits_balance(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        api_key: str,
+        make_api_user: MakeApiUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An admin's kudos delta on a user credits that user's balance by the delta."""
+        from horde.database import functions as database
+
+        with app.app_context():
+            admin_alias = database.find_user_by_api_key(api_key).get_unique_alias()
+        monkeypatch.setenv("ADMINS", json.dumps([admin_alias]))
+
+        target = make_api_user(kudos=0)
+        target_before = _user_kudos(app, target.id)
+
+        resp = client.put(
+            f"/api/v2/users/{target.id}",
+            json={"kudos": 1000},
+            headers=_headers(api_key),
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert _user_kudos(app, target.id) == target_before + 1000
+
+    def test_admin_monthly_kudos_grant_credits_immediately(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        api_key: str,
+        make_api_user: MakeApiUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An admin's monthly-kudos grant is stored as entitlement and credited to balance at once."""
+        from horde.database import functions as database
+
+        with app.app_context():
+            admin_alias = database.find_user_by_api_key(api_key).get_unique_alias()
+        monkeypatch.setenv("ADMINS", json.dumps([admin_alias]))
+
+        target = make_api_user(kudos=0)
+        target_before = _user_kudos(app, target.id)
+
+        resp = client.put(
+            f"/api/v2/users/{target.id}",
+            json={"monthly_kudos": 500},
+            headers=_headers(api_key),
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+
+        with app.app_context():
+            refreshed = database.find_user_by_id(target.id)
+            assert refreshed.monthly_kudos == 500
+            assert refreshed.kudos == target_before + 500
+
+
+class TestDeadCodeGuard:
+    """The Kobold kudos-transfer resource is dead code and stays unregistered on the API."""
+
+    def test_kobold_kudos_transfer_is_not_registered(self, app: Flask) -> None:
+        """The live transfer and award resources are registered while the Kobold transfer resource is not."""
+        import horde.apis.v2  # noqa: F401  (ensures resources are registered)
+        from horde.apis.v2 import base, kobold
+
+        registered = {resource[0] for resource in base.api.resources}
+        assert base.TransferKudos in registered
+        assert base.AwardKudos in registered
+        # The Kobold transfer resource remains dead code, reachable by no route.
+        assert kobold.KoboldKudosTransfer not in registered

--- a/tests/integration/test_kudos_request_activation.py
+++ b/tests/integration/test_kudos_request_activation.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2026 Tazlin <tazlin@haidra.net>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Endpoint characterization for request-activation kudos effects.
+
+Submitting an image request charges the requester an up-front horde tax at
+activation and seeds the request's queue priority from the requester's current
+balance. The anonymous user is charged the same tax as a registered user. When
+a request needs kudos up front and the requester cannot cover the estimated
+cost, activation is refused and nothing is charged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from tests.fixture_types import MakeApiUser
+
+AGENT: str = "aihorde_ci_client:1.0:(test)ci"
+ANON_API_KEY: str = "0000000000"
+
+SMALL_REQUEST: dict[str, object] = {
+    "prompt": "a horde of small test robots",
+    "nsfw": False,
+    "params": {"width": 512, "height": 512, "steps": 8, "cfg_scale": 1.5, "sampler_name": "k_euler_a"},
+    "models": ["stable_diffusion"],
+    "allow_downgrade": False,
+}
+
+# A request whose step count exceeds the free-tier ceiling always needs kudos
+# up front, so the upfront gate turns purely on whether the requester can cover it.
+GATED_REQUEST: dict[str, object] = {
+    "prompt": "a horde of demanding test robots",
+    "nsfw": False,
+    "params": {"width": 512, "height": 512, "steps": 50, "cfg_scale": 1.5, "sampler_name": "k_euler_a"},
+    "models": ["stable_diffusion"],
+    "allow_downgrade": False,
+}
+
+# The up-front horde tax charged at activation for a minimal single-image request.
+ACTIVATION_TAX: int = 3
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limit() -> Iterator[None]:
+    """Disable the rate limiter for the duration of a test."""
+    from horde.limiter import limiter
+
+    previous = limiter.enabled
+    limiter.enabled = False
+    yield
+    limiter.enabled = previous
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    """Return request headers carrying the given API key and the test client agent."""
+    return {"apikey": api_key, "Client-Agent": AGENT}
+
+
+class TestActivationDebit:
+    """Submitting a request charges an up-front horde tax against the requester's balance."""
+
+    def test_registered_request_debits_the_requester(self, client: FlaskClient, app: Flask, api_key: str) -> None:
+        """A registered requester's balance drops by the activation tax when a request is submitted."""
+        from horde.database import functions as database
+
+        with app.app_context():
+            uid = database.find_user_by_api_key(api_key).id
+            before = database.find_user_by_id(uid).kudos
+
+        resp = client.post("/api/v2/generate/async", json=SMALL_REQUEST, headers=_headers(api_key))
+        assert resp.status_code == 202, resp.get_data(as_text=True)
+
+        with app.app_context():
+            after = database.find_user_by_id(uid).kudos
+        assert after == before - ACTIVATION_TAX
+
+    def test_anonymous_request_debits_the_anonymous_user(self, client: FlaskClient, app: Flask) -> None:
+        """The anonymous user is charged the same activation tax as a registered requester."""
+        from horde.database import functions as database
+        from horde.flask import db
+
+        with app.app_context():
+            anon = database.find_user_by_id(0)
+            # Pin the anonymous balance clear of its floor so the debit is observable.
+            anon.kudos = 100
+            db.session.commit()
+
+        resp = client.post("/api/v2/generate/async", json=SMALL_REQUEST, headers=_headers(ANON_API_KEY))
+        assert resp.status_code == 202, resp.get_data(as_text=True)
+
+        with app.app_context():
+            after = database.find_user_by_id(0).kudos
+        assert after == 100 - ACTIVATION_TAX
+
+
+class TestPrioritySeeding:
+    """A request's queue priority is derived from the requester's balance at activation."""
+
+    def test_priority_is_seeded_from_the_requester_balance(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        api_key: str,
+    ) -> None:
+        """A request's queue priority is seeded from the requester's balance before the tax is deducted."""
+        from horde.database import functions as database
+
+        with app.app_context():
+            balance = database.find_user_by_api_key(api_key).kudos
+
+        resp = client.post("/api/v2/generate/async", json=SMALL_REQUEST, headers=_headers(api_key))
+        assert resp.status_code == 202, resp.get_data(as_text=True)
+        wp_id = resp.get_json()["id"]
+
+        with app.app_context():
+            wp = database.get_wp_by_id(wp_id)
+            # The queue priority is seeded from the balance held at activation time
+            # (before the horde tax is deducted).
+            assert wp.extra_priority == balance
+
+
+class TestUpfrontGate:
+    """A request needing up-front kudos is admitted only when the requester can cover the estimated cost."""
+
+    def test_insufficient_balance_is_refused_and_charges_nothing(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        make_api_user: MakeApiUser,
+    ) -> None:
+        """A request needing up-front kudos is refused and charges nothing when the requester cannot cover it."""
+        from horde.database import functions as database
+
+        requester = make_api_user(kudos=0)
+
+        resp = client.post("/api/v2/generate/async", json=GATED_REQUEST, headers=_headers(requester.api_key))
+        assert resp.status_code == 403
+        assert resp.get_json()["rc"] == "KudosUpfront"
+
+        with app.app_context():
+            # The refusal charges nothing.
+            assert database.find_user_by_id(requester.id).kudos == 0
+
+    def test_sufficient_balance_is_accepted(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        make_api_user: MakeApiUser,
+    ) -> None:
+        """A request needing up-front kudos is accepted when the requester can cover the estimated cost."""
+        requester = make_api_user(kudos=100000)
+        resp = client.post("/api/v2/generate/async", json=GATED_REQUEST, headers=_headers(requester.api_key))
+        assert resp.status_code == 202, resp.get_data(as_text=True)

--- a/tests/stress/locustsuite/users/hot_user_convoy.py
+++ b/tests/stress/locustsuite/users/hot_user_convoy.py
@@ -334,7 +334,11 @@ class HeavyProxyRequester(HttpUser):
             if resp.status_code == 429 or (resp.status_code == 400 and _is_expected_rc(body, _EXPECTED_ASYNC_RC)):
                 resp.success()
                 _record_expected(
-                    self.environment, "POST", "[hc] async heavy", resp.elapsed.total_seconds() * 1000, len(resp.content or b""),
+                    self.environment,
+                    "POST",
+                    "[hc] async heavy",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
                 )
                 return
             resp.failure(f"heavy async failed: {resp.status_code}: {resp.text[:200]}")
@@ -529,7 +533,11 @@ class KudosTransfer(HttpUser):
             if resp.status_code == 429 or (resp.status_code == 400 and _is_expected_rc(body, _EXPECTED_KUDOS_RC)):
                 resp.success()
                 _record_expected(
-                    self.environment, "POST", "[hc] kudos transfer", resp.elapsed.total_seconds() * 1000, len(resp.content or b""),
+                    self.environment,
+                    "POST",
+                    "[hc] kudos transfer",
+                    resp.elapsed.total_seconds() * 1000,
+                    len(resp.content or b""),
                 )
                 return
             resp.failure(f"kudos transfer failed: {resp.status_code}: {resp.text[:200]}")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,13 +14,23 @@ from __future__ import annotations
 import contextlib
 import uuid
 from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import sqlalchemy
 from sqlalchemy import event
 
 from tests.dependency_runtime import create_schema, drop_schema, new_test_schema_name
+from tests.fixture_types import MakeUser, MakeUserRole
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from flask.testing import FlaskClient
+    from flask_sqlalchemy.session import Session
+    from sqlalchemy.orm import scoped_session
+
+    from horde.classes.base.user import User, UserRole
+    from horde.enums import UserRoleTypes
 
 
 @pytest.fixture(scope="session")
@@ -40,7 +50,7 @@ def _pg_schema(_pg_dsn: str) -> Iterator[str]:
 
 
 @pytest.fixture(scope="session")
-def app(_pg_dsn: str, _pg_schema: str):
+def app(_pg_dsn: str, _pg_schema: str) -> Iterator[Flask]:
     """Flask app pointed at test Postgres with an isolated schema."""
     from horde.flask import create_app, db
 
@@ -70,13 +80,13 @@ def app(_pg_dsn: str, _pg_schema: str):
 
 
 @pytest.fixture
-def client(app):
+def client(app: Flask) -> FlaskClient:
     """Flask test client."""
     return app.test_client()
 
 
 @pytest.fixture
-def db_session(app) -> Iterator[Any]:
+def db_session(app: Flask) -> Iterator[scoped_session[Session]]:
     """Per-test ORM session. Truncates all tables after each test.
 
     Tests are free to call ``db.session.commit()``. The truncation runs
@@ -186,7 +196,7 @@ def _unique_suffix() -> str:
 
 
 @pytest.fixture
-def make_user(db_session):
+def make_user(db_session: scoped_session[Session]) -> MakeUser:
     """Factory: build and persist a ``User`` with sensible defaults.
 
     Returns a callable. Any kwarg overrides a default field. The user is
@@ -194,7 +204,7 @@ def make_user(db_session):
     """
     from horde.classes.base.user import User
 
-    def _make(**overrides: Any):
+    def _make(**overrides: Any) -> User:
         suffix = _unique_suffix()
         defaults: dict[str, Any] = {
             "username": f"test_user_{suffix}",
@@ -211,11 +221,11 @@ def make_user(db_session):
 
 
 @pytest.fixture
-def make_user_role(db_session):
+def make_user_role(db_session: scoped_session[Session]) -> MakeUserRole:
     """Factory: attach a ``UserRole`` to a user."""
     from horde.classes.base.user import UserRole
 
-    def _make(user, role_type, *, value: bool = True):
+    def _make(user: User, role_type: UserRoleTypes, *, value: bool = True) -> UserRole:
         role = UserRole(user_id=user.id, user_role=role_type, value=value)
         db_session.add(role)
         db_session.flush()

--- a/tests/unit/test_kudos_balance.py
+++ b/tests/unit/test_kudos_balance.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 Tazlin
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Characterization of the core kudos balance primitives.
+
+Covers the per-account balance mutation (``User.modify_kudos`` and
+``Worker.modify_kudos``) and the per-user-class balance floor. These are the
+lowest-level accounting operations every kudos flow builds on: a signed delta is
+added to the balance, the running per-action total is recorded, and a user
+balance can never fall below the floor for that user's class. Worker balances
+accrue independently and carry no floor.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from horde.classes.base.user import User, UserStats
+from horde.classes.base.worker import WorkerStats, WorkerTemplate
+from tests.fixture_types import MakeUser
+
+
+def _stats_value(db_session: Session, user_id: int, action: str) -> int:
+    """Return the recorded per-action total for a user, asserting the row exists."""
+    row = db_session.query(UserStats).filter_by(user_id=user_id, action=action).first()
+    assert row is not None, f"expected a UserStats row for user {user_id} action {action!r}"
+    return row.value
+
+
+def _make_worker(db_session: Session, owner: User) -> WorkerTemplate:
+    """Create a persisted generic worker owned by the given user."""
+    worker = WorkerTemplate(name=f"worker_{uuid.uuid4().hex[:12]}", user_id=owner.id)
+    db_session.add(worker)
+    db_session.flush()
+    return worker
+
+
+class TestUserBalanceDelta:
+    """A signed delta moves a user's balance and accrues a per-action total."""
+
+    def test_positive_delta_raises_balance(self, db_session: Session, make_user: MakeUser) -> None:
+        """A positive delta increases the balance by that amount."""
+        user = make_user(kudos=1000)
+        user.modify_kudos(250, "award")
+        assert user.kudos == 1250
+
+    def test_negative_delta_lowers_balance(self, db_session: Session, make_user: MakeUser) -> None:
+        """A negative delta decreases the balance by that amount."""
+        user = make_user(kudos=1000)
+        user.modify_kudos(-250, "accumulated")
+        assert user.kudos == 750
+
+    def test_action_total_accumulates_across_calls(self, db_session: Session, make_user: MakeUser) -> None:
+        """Repeated deltas for one action sum into that action's running total."""
+        user = make_user(kudos=1000)
+        user.modify_kudos(50, "award")
+        user.modify_kudos(25, "award")
+        assert user.kudos == 1075
+        assert _stats_value(db_session, user.id, "award") == 75
+
+    def test_distinct_actions_are_tracked_separately(self, db_session: Session, make_user: MakeUser) -> None:
+        """Each action keeps its own independent running total."""
+        user = make_user(kudos=1000)
+        user.modify_kudos(40, "award")
+        user.modify_kudos(-10, "accumulated")
+        assert _stats_value(db_session, user.id, "award") == 40
+        assert _stats_value(db_session, user.id, "accumulated") == -10
+
+
+class TestWorkerBalanceDelta:
+    """Worker balances accrue per action independently and carry no floor."""
+
+    def test_positive_delta_raises_worker_balance(self, db_session: Session, make_user: MakeUser) -> None:
+        """A positive delta increases a worker's balance."""
+        owner = make_user(kudos=100)
+        worker = _make_worker(db_session, owner)
+        worker.modify_kudos(100, "generated")
+        assert worker.kudos == 100
+
+    def test_worker_action_total_accumulates(self, db_session: Session, make_user: MakeUser) -> None:
+        """Repeated deltas accumulate into the worker's per-action total."""
+        owner = make_user(kudos=100)
+        worker = _make_worker(db_session, owner)
+        worker.modify_kudos(100, "generated")
+        worker.modify_kudos(40, "generated")
+        assert worker.kudos == 140
+        row = db_session.query(WorkerStats).filter_by(worker_id=worker.id, action="generated").first()
+        assert row is not None
+        assert row.value == 140
+
+    def test_worker_balance_has_no_floor(self, db_session: Session, make_user: MakeUser) -> None:
+        """A worker balance may go arbitrarily negative."""
+        owner = make_user(kudos=100)
+        worker = _make_worker(db_session, owner)
+        worker.modify_kudos(-500, "generated")
+        assert worker.kudos == -500
+
+
+class TestBalanceFloor:
+    """A debit below a user-class floor clamps the balance to that floor."""
+
+    def test_anonymous_floor_is_negative_fifty(self, db_session: Session, make_user: MakeUser) -> None:
+        """The anonymous user's balance floor is -50 kudos."""
+        anon = make_user(username="Anonymous", oauth_id="anon", kudos=10)
+        assert anon.get_min_kudos() == -50
+        anon.modify_kudos(-100, "accumulated")
+        assert anon.kudos == -50
+
+    def test_named_floor_is_twenty_five(self, db_session: Session, make_user: MakeUser) -> None:
+        """A named user's balance floor is 25 kudos."""
+        user = make_user(kudos=30)
+        assert user.get_min_kudos() == 25
+        user.modify_kudos(-100, "accumulated")
+        assert user.kudos == 25
+
+    def test_pseudonymous_floor_is_fourteen(self, db_session: Session, make_user: MakeUser) -> None:
+        """A pseudonymous user's balance floor is 14 kudos."""
+        user = make_user(oauth_id=str(uuid.uuid4()), kudos=20)
+        assert user.get_min_kudos() == 14
+        user.modify_kudos(-100, "accumulated")
+        assert user.kudos == 14
+
+    def test_debit_at_floor_stays_at_floor(self, db_session: Session, make_user: MakeUser) -> None:
+        """A further debit applied at the floor leaves the balance at the floor."""
+        anon = make_user(username="Anonymous", oauth_id="anon", kudos=10)
+        anon.modify_kudos(-100, "accumulated")
+        assert anon.kudos == -50
+        anon.modify_kudos(-5, "accumulated")
+        assert anon.kudos == -50
+
+    def test_balance_above_floor_is_left_untouched(self, db_session: Session, make_user: MakeUser) -> None:
+        """A debit that stays above the floor is applied in full."""
+        user = make_user(kudos=1000)
+        user.modify_kudos(-100, "accumulated")
+        assert user.kudos == 900

--- a/tests/unit/test_kudos_image_cancel.py
+++ b/tests/unit/test_kudos_image_cancel.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2026 Tazlin
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Characterization of settlement when an in-flight image generation is cancelled.
+
+Cancelling a generation a worker is still processing is not free: the work
+already in progress settles exactly as a normal submission would. The
+contributing worker and its owner are credited the generation's kudos and the
+requester is debited that kudos plus the request burn. A generation that has
+already completed or faulted is inert: cancelling it settles nothing.
+
+The image pop/submit HTTP lifecycle depends on S3-compatible object storage, so
+cancellation settlement is characterized against the real
+``ImageProcessingGeneration.cancel`` on a persisted ORM graph rather than driven
+end to end over HTTP.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from horde.classes.base.user import User
+from horde.classes.stable.processing_generation import ImageProcessingGeneration
+from horde.classes.stable.waiting_prompt import ImageWaitingPrompt
+from horde.classes.stable.worker import ImageWorker
+from horde.enums import UserRoleTypes
+from tests.fixture_types import MakeUser, MakeUserRole
+
+GEN_KUDOS: int = 50
+# calculate_extra_kudos_burn adds a flat +1 request burn (with slow_workers set,
+# the non-slow 1.2x multiplier does not apply).
+REQUEST_BURN: int = 1
+# The worker/owner credit is scaled by the bridge multiplier; a non-official
+# bridge (the default unknown agent) is rewarded at 0.75x. The requester debit is
+# not scaled by the multiplier.
+BRIDGE_MULTIPLIER: float = 0.75
+WORKER_REWARD: float = GEN_KUDOS * BRIDGE_MULTIPLIER
+
+
+@pytest.fixture(autouse=True)
+def _trust_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KUDOS_TRUST_THRESHOLD", "100000")
+
+
+def _build_processing_generation(db_session: Session, requester: User, owner: User) -> ImageProcessingGeneration:
+    """Create a persisted, still-processing image generation for the given requester and owner."""
+    worker = ImageWorker(name=f"worker_{uuid.uuid4().hex[:8]}", user_id=owner.id)
+    db_session.add(worker)
+    db_session.flush()
+
+    wp = ImageWaitingPrompt(
+        worker_ids=[],
+        models=["stable_diffusion"],
+        prompt="a test robot",
+        user_id=requester.id,
+        params={"width": 512, "height": 512, "steps": 8, "sampler_name": "k_euler_a"},
+    )
+    # Pin the per-generation reward and suppress the non-slow burn multiplier so the
+    # settlement amounts are exact (test-bootstrap absolute set on the WP columns).
+    wp.kudos = GEN_KUDOS
+    wp.slow_workers = True
+    db_session.flush()
+
+    procgen = ImageProcessingGeneration(wp_id=wp.id, worker_id=worker.id, model="stable_diffusion")
+    db_session.flush()
+    return procgen
+
+
+class TestInFlightCancelSettles:
+    """Cancelling a still-processing generation settles it like a submission."""
+
+    def test_worker_and_owner_are_credited(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """Cancellation credits the worker and its owner the bridge-adjusted reward and returns it."""
+        requester = make_user(kudos=1000)
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        procgen = _build_processing_generation(db_session, requester, owner)
+
+        returned = procgen.cancel()
+
+        assert procgen.worker.kudos == WORKER_REWARD
+        assert owner.kudos == 1000 + WORKER_REWARD
+        # cancel returns the bridge-adjusted worker reward.
+        assert returned == WORKER_REWARD
+
+    def test_requester_is_debited_gen_kudos_plus_burn(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """Cancellation debits the requester the generation kudos plus the request burn."""
+        requester = make_user(kudos=1000)
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        procgen = _build_processing_generation(db_session, requester, owner)
+
+        procgen.cancel()
+
+        assert requester.kudos == 1000 - (GEN_KUDOS + REQUEST_BURN)
+
+    def test_cancel_marks_the_generation_faulted(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """Cancellation marks the generation both faulted and cancelled."""
+        requester = make_user(kudos=1000)
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        procgen = _build_processing_generation(db_session, requester, owner)
+
+        procgen.cancel()
+
+        assert procgen.faulted is True
+        assert procgen.cancelled is True
+
+
+class TestAlreadySettledCancelIsInert:
+    """Cancelling an already-finished generation moves no kudos."""
+
+    def test_faulted_generation_cancel_settles_nothing(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """Cancelling an already-faulted generation moves no kudos and returns nothing."""
+        requester = make_user(kudos=1000)
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        procgen = _build_processing_generation(db_session, requester, owner)
+        procgen.faulted = True
+        db_session.flush()
+
+        result = procgen.cancel()
+
+        assert result is None
+        assert procgen.worker.kudos == 0
+        assert owner.kudos == 1000
+        assert requester.kudos == 1000

--- a/tests/unit/test_kudos_interrogation.py
+++ b/tests/unit/test_kudos_interrogation.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 Tazlin
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Characterization of interrogation (alchemy) form settlement.
+
+When an interrogation form is delivered, the worker and its owner are credited
+the form's kudos (the owner's share following the usual trust routing) and the
+requesting user is debited the form's kudos plus a fixed burn. The burn is one
+kudos, raised to two when the request opted into slow workers.
+
+The interrogation pop/submit HTTP lifecycle depends on S3-compatible object
+storage, so settlement is characterized against the real
+``InterrogationForms.record`` on a persisted ORM graph rather than driven end to
+end over HTTP.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy.orm import Session
+
+from horde.classes.base.user import User
+from horde.classes.stable.interrogation import Interrogation, InterrogationForms
+from horde.classes.stable.interrogation_worker import InterrogationWorker
+from horde.enums import State, UserRoleTypes
+from tests.fixture_types import MakeUser, MakeUserRole
+
+
+@pytest.fixture(autouse=True)
+def _trust_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KUDOS_TRUST_THRESHOLD", "100000")
+
+
+def _build_processing_form(
+    db_session: Session,
+    requester: User,
+    owner: User,
+    *,
+    kudos: float = 3,
+    slow_workers: bool = False,
+) -> InterrogationForms:
+    """Create a persisted, still-processing interrogation form for the given requester and owner."""
+    interrogation = Interrogation(user_id=requester.id, slow_workers=slow_workers)
+    worker = InterrogationWorker(name=f"iw_{uuid.uuid4().hex[:8]}", user_id=owner.id)
+    db_session.add(worker)
+    db_session.flush()
+    # The legacy declarative InterrogationForms model has an untyped implicit
+    # constructor, so each keyword is suppressed for pyrefly's benefit only.
+    form = InterrogationForms(
+        i_id=interrogation.id,
+        name="caption",
+        kudos=kudos,
+        state=State.PROCESSING,
+        worker_id=worker.id,
+        initiated=datetime.utcnow(),
+    )
+    db_session.add(form)
+    db_session.flush()
+    return form
+
+
+class TestInterrogationSettlement:
+    """Delivering a form credits the worker and owner and debits the requester with a burn."""
+
+    def test_trusted_owner_settlement(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """A trusted owner is credited on the balance while the requester pays kudos plus burn."""
+        requester = make_user(kudos=1000)
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        form = _build_processing_form(db_session, requester, owner, kudos=3)
+
+        form.record(form.kudos)
+
+        assert form.worker.kudos == 3
+        assert owner.kudos == 1003
+        # The requester pays the form kudos plus the one-kudos burn.
+        assert requester.kudos == 1000 - (3 + 1)
+
+    def test_untrusted_owner_share_is_escrowed(self, db_session: Session, make_user: MakeUser) -> None:
+        """An untrusted owner's share is split between the balance and evaluation escrow."""
+        requester = make_user(kudos=1000)
+        owner = make_user(kudos=1000)
+        form = _build_processing_form(db_session, requester, owner, kudos=4)
+
+        form.record(form.kudos)
+
+        assert form.worker.kudos == 4
+        # Half the owner's credit is withheld for evaluation while untrusted.
+        assert owner.kudos == 1002
+        assert owner.evaluating_kudos == 2
+        assert requester.kudos == 1000 - (4 + 1)
+
+    def test_slow_worker_request_burns_an_extra_kudos(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """A slow-worker request raises the requester's burn from one to two."""
+        requester = make_user(kudos=1000)
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        form = _build_processing_form(db_session, requester, owner, kudos=3, slow_workers=True)
+
+        form.record(form.kudos)
+
+        assert requester.kudos == 1000 - (3 + 2)

--- a/tests/unit/test_kudos_invariants.py
+++ b/tests/unit/test_kudos_invariants.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2026 Tazlin
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Kudos invariants the implementation is intended to honour but does not yet.
+
+Each test pins a contract the system is meant to satisfy and asserts the intended
+behaviour directly. Because the underlying flows still violate these contracts,
+the tests are marked ``xfail(strict=True)``: they register as expected failures
+and stay out of the green characterization baseline. When a defect is corrected
+its test begins to pass, the strict marker turns that pass into a hard failure,
+and the failure is the signal to drop the marker and fold the case into the
+baseline.
+
+The pinned contracts:
+  * An interrogation worker crossing its uptime threshold grants an untrusted
+    owner exactly one reward, and the untrusted-owner bypass places that reward
+    on the spendable balance without also minting evaluation escrow.
+  * Cancelling an interrogation form the worker is still processing settles it
+    like a submission: the worker and owner are credited and the requester is
+    debited the form kudos plus burn.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+
+from horde.classes.base.user import User
+from horde.classes.stable.interrogation import Interrogation, InterrogationForms
+from horde.classes.stable.interrogation_worker import InterrogationWorker
+from horde.enums import State, UserRoleTypes
+from tests.fixture_types import MakeUser, MakeUserRole
+
+INTERROGATION_UPTIME_REWARD: int = 40
+FORM_KUDOS: int = 3
+FORM_BURN: int = 1
+
+
+@pytest.fixture(autouse=True)
+def _trust_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KUDOS_TRUST_THRESHOLD", "100000")
+
+
+def _primed_uptime_worker(db_session: Session, owner: User) -> InterrogationWorker:
+    """Create an interrogation worker primed to cross its uptime reward threshold on the next check-in."""
+    worker = InterrogationWorker(name=f"iw_{uuid.uuid4().hex[:8]}", user_id=owner.id)
+    db_session.add(worker)
+    db_session.flush()
+    worker.last_check_in = datetime.utcnow() - timedelta(seconds=40)
+    worker.uptime = worker.uptime_reward_threshold - 10
+    worker.last_reward_uptime = 0
+    db_session.flush()
+    return worker
+
+
+def _processing_form(db_session: Session, requester: User, owner: User) -> InterrogationForms:
+    """Create a persisted, still-processing interrogation form for the given requester and owner."""
+    interrogation = Interrogation(user_id=requester.id, slow_workers=False)
+    worker = InterrogationWorker(name=f"iw_{uuid.uuid4().hex[:8]}", user_id=owner.id)
+    db_session.add(worker)
+    db_session.flush()
+    # The legacy declarative InterrogationForms model has an untyped implicit
+    # constructor, so each keyword is suppressed for pyrefly's benefit only.
+    form = InterrogationForms(
+        i_id=interrogation.id,
+        name="caption",
+        kudos=FORM_KUDOS,
+        state=State.PROCESSING,
+        worker_id=worker.id,
+        initiated=datetime.utcnow(),
+    )
+    db_session.add(form)
+    db_session.flush()
+    return form
+
+
+@pytest.mark.xfail(strict=True, reason="Untrusted alchemist owner is double-credited (balance and escrow) per crossing.")
+def test_interrogation_uptime_credits_untrusted_owner_balance_without_escrow(
+    db_session: Session,
+    make_user: MakeUser,
+) -> None:
+    """The untrusted-owner bypass places the whole interrogation uptime reward on the balance and mints no escrow."""
+    owner = make_user(kudos=1000)  # untrusted, non-anonymous
+    worker = _primed_uptime_worker(db_session, owner)
+
+    worker.check_in(4, forms=["caption"], ipaddr="10.0.0.1")
+
+    # The bypass routes the whole reward to the spendable balance...
+    assert owner.kudos == 1000 + INTERROGATION_UPTIME_REWARD
+    # ...and no evaluation escrow is created by the same crossing.
+    assert owner.evaluating_kudos == 0
+
+
+@pytest.mark.xfail(strict=True, reason="Untrusted alchemist owner is double-credited (balance and escrow) per crossing.")
+def test_interrogation_uptime_grants_untrusted_owner_exactly_one_reward(
+    db_session: Session,
+    make_user: MakeUser,
+) -> None:
+    """An interrogation uptime crossing grants an untrusted owner exactly one reward across balance and escrow."""
+    owner = make_user(kudos=1000)
+    worker = _primed_uptime_worker(db_session, owner)
+
+    worker.check_in(4, forms=["caption"], ipaddr="10.0.0.1")
+
+    total_gain = (owner.kudos - 1000) + owner.evaluating_kudos
+    assert total_gain == INTERROGATION_UPTIME_REWARD
+
+
+@pytest.mark.xfail(
+    strict=True, reason="Cancelling a PROCESSING interrogation form flips state before the settle check, so it settles nothing."
+)
+def test_cancelling_in_flight_interrogation_form_settles_like_a_submit(
+    db_session: Session,
+    make_user: MakeUser,
+    make_user_role: MakeUserRole,
+) -> None:
+    """Cancelling a still-processing interrogation form settles it like a submission."""
+    requester = make_user(kudos=1000)
+    owner = make_user(kudos=1000)
+    make_user_role(owner, UserRoleTypes.TRUSTED)
+    form = _processing_form(db_session, requester, owner)
+
+    form.cancel()
+
+    assert form.worker.kudos == FORM_KUDOS
+    assert owner.kudos == 1000 + FORM_KUDOS
+    assert requester.kudos == 1000 - (FORM_KUDOS + FORM_BURN)

--- a/tests/unit/test_kudos_monthly.py
+++ b/tests/unit/test_kudos_monthly.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2026 Tazlin
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Characterization of monthly kudos entitlements.
+
+Users with a monthly entitlement (moderators, patrons, or an admin-granted
+allowance) are credited that entitlement once per calendar month. Granting or
+changing an entitlement credits the difference to the balance immediately and
+never lets the stored entitlement go negative. The recurring award advances a
+per-user cursor by exactly one month so it cannot be claimed twice in the same
+period.
+
+The patreon and stripe integrations are external services outside the kudos
+contract under test; they are pinned to contribute nothing so the in-database
+entitlement behaviour is observed deterministically.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import dateutil.relativedelta
+import pytest
+from sqlalchemy.orm import Session
+
+from horde.classes.base import user as user_module
+from horde.enums import UserRoleTypes
+from tests.fixture_types import MakeUser, MakeUserRole
+
+MODERATOR_MONTHLY_BONUS: int = 300000
+
+
+@pytest.fixture(autouse=True)
+def _no_external_subscriptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(user_module.patrons, "get_monthly_kudos", lambda user_id: 0)
+    monkeypatch.setattr(user_module.stripe_subs, "get_monthly_kudos", lambda user_id: 0)
+
+
+class TestModifyMonthlyEntitlement:
+    """Granting an entitlement credits the difference immediately."""
+
+    def test_positive_grant_credits_balance_and_stores_entitlement(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+    ) -> None:
+        """A positive grant credits the balance and stores the entitlement."""
+        user = make_user(kudos=1000)
+        user.modify_monthly_kudos(500)
+        assert user.kudos == 1500
+        assert user.monthly_kudos == 500
+        assert user.monthly_kudos_last_received is not None
+
+    def test_increasing_entitlement_credits_only_the_difference(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+    ) -> None:
+        """Raising an entitlement credits only the increase and leaves the received-date cursor untouched."""
+        user = make_user(kudos=1000)
+        user.modify_monthly_kudos(500)
+        first_received = user.monthly_kudos_last_received
+        user.modify_monthly_kudos(200)
+        assert user.kudos == 1700
+        assert user.monthly_kudos == 700
+        assert user.monthly_kudos_last_received == first_received
+
+    def test_entitlement_never_goes_negative_and_debits_nothing(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+    ) -> None:
+        """A reduction clamps the stored entitlement at zero and never debits the balance."""
+        user = make_user(kudos=1000)
+        user.modify_monthly_kudos(100)
+        user.modify_monthly_kudos(-500)
+        assert user.monthly_kudos == 0
+        assert user.kudos == 1100
+
+
+class TestReceiveMonthlyKudos:
+    """The recurring award credits the entitlement once per month."""
+
+    def test_entitlement_credited_on_first_receipt(self, db_session: Session, make_user: MakeUser) -> None:
+        """The first receipt credits the stored entitlement and stamps the received-date cursor."""
+        user = make_user(kudos=1000)
+        user.monthly_kudos = 500
+        db_session.flush()
+        user.receive_monthly_kudos()
+        assert user.kudos == 1500
+        assert user.monthly_kudos_last_received is not None
+
+    def test_moderator_bonus_is_credited(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """A moderator receives the monthly bonus on top of any entitlement."""
+        user = make_user(kudos=1000)
+        make_user_role(user, UserRoleTypes.MODERATOR)
+        db_session.flush()
+        user.receive_monthly_kudos()
+        assert user.kudos == 1000 + MODERATOR_MONTHLY_BONUS
+
+    def test_cursor_advances_by_one_month(self, db_session: Session, make_user: MakeUser) -> None:
+        """Receipt advances the received-date cursor exactly one month from its prior value."""
+        user = make_user(kudos=1000)
+        previous = datetime.utcnow() - timedelta(days=40)
+        user.monthly_kudos = 500
+        user.monthly_kudos_last_received = previous
+        db_session.flush()
+
+        user.receive_monthly_kudos()
+
+        assert user.kudos == 1500
+        expected = previous + dateutil.relativedelta.relativedelta(months=+1)
+        assert user.monthly_kudos_last_received == expected
+
+    def test_no_second_award_within_the_same_period(self, db_session: Session, make_user: MakeUser) -> None:
+        """A second receipt within the same month credits nothing and leaves the cursor untouched."""
+        user = make_user(kudos=1000)
+        just_received = datetime.utcnow()
+        user.monthly_kudos = 500
+        user.monthly_kudos_last_received = just_received
+        db_session.flush()
+
+        user.receive_monthly_kudos()
+
+        assert user.kudos == 1000
+        assert user.monthly_kudos_last_received == just_received
+
+
+class TestCalculateMonthlyKudos:
+    """The awarded amount sums the stored entitlement and the moderator bonus."""
+
+    def test_plain_entitlement(self, db_session: Session, make_user: MakeUser) -> None:
+        """A plain user's calculated award equals the stored entitlement."""
+        user = make_user(kudos=1000)
+        user.monthly_kudos = 250
+        db_session.flush()
+        assert user.calculate_monthly_kudos() == 250
+
+    def test_moderator_adds_bonus(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """A moderator's calculated award adds the bonus to the stored entitlement."""
+        user = make_user(kudos=1000)
+        user.monthly_kudos = 250
+        make_user_role(user, UserRoleTypes.MODERATOR)
+        db_session.flush()
+        assert user.calculate_monthly_kudos() == 250 + MODERATOR_MONTHLY_BONUS

--- a/tests/unit/test_kudos_pricing.py
+++ b/tests/unit/test_kudos_pricing.py
@@ -22,13 +22,18 @@ them via ``python -m horde.classes.stable.kudos <npz>``.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 import pytest
+
+if TYPE_CHECKING:
+    from horde.classes.stable.kudos import KudosModel
 
 pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(scope="module")
-def kudos_model():
+def kudos_model() -> KudosModel:
     """Load the singleton ``KudosModel`` once for the module."""
     # Import inside the fixture so the module-level KudosModel() in
     # horde.classes.stable.kudos doesn't fire during collection-only runs.
@@ -38,21 +43,25 @@ def kudos_model():
 
 
 @pytest.fixture
-def basis_payload():
-    """A fresh copy of BASIS_PAYLOAD per test (KudosModel mutates payloads in place via .get)."""
+def basis_payload() -> dict[str, Any]:
+    """Return a fresh copy of BASIS_PAYLOAD per test (KudosModel mutates payloads in place via .get)."""
     from horde.classes.stable.kudos import KudosModel
 
     return dict(KudosModel.BASIS_PAYLOAD)
 
 
 class TestModelLoad:
-    def test_singleton_returned_on_repeat_construction(self, kudos_model):
+    """Constructing the model yields the shared singleton with a computed time basis."""
+
+    def test_singleton_returned_on_repeat_construction(self, kudos_model: KudosModel) -> None:
+        """Repeated construction returns the same singleton instance."""
         from horde.classes.stable.kudos import KudosModel
 
         assert KudosModel() is kudos_model
         assert KudosModel() is KudosModel()
 
-    def test_time_basis_was_calculated(self, kudos_model):
+    def test_time_basis_was_calculated(self, kudos_model: KudosModel) -> None:
+        """The singleton's time basis is computed during construction."""
         # calculate_basis_time runs in __init__; a zero here means the
         # singleton init didn't complete.
         assert kudos_model.time_basis > 0
@@ -61,7 +70,12 @@ class TestModelLoad:
 class TestDesignIntent:
     """The model should approximately honour its design contract."""
 
-    def test_golden_payload_outputs_match_converted_checkpoint(self, kudos_model, basis_payload):
+    def test_golden_payload_outputs_match_converted_checkpoint(
+        self,
+        kudos_model: KudosModel,
+        basis_payload: dict[str, Any],
+    ) -> None:
+        """Representative payloads price to the golden times and kudos of the converted checkpoint."""
         payloads = {
             "basis": basis_payload,
             "large": dict(basis_payload, width=1024, height=1024),
@@ -98,8 +112,8 @@ class TestDesignIntent:
             assert kudos_model.payload_to_time(payload) == expected_time
             assert kudos_model.calculate_kudos(payload) == expected_kudos
 
-    def test_basis_payload_is_close_to_kudos_basis(self, kudos_model, basis_payload):
-        """A 50-step 512×512 generation should cost ~10 kudos.
+    def test_basis_payload_is_close_to_kudos_basis(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """A 50-step 512×512 generation costs approximately KUDOS_BASIS (10) kudos.
 
         This is the model's documented design intent (see ``KudosModel.KUDOS_BASIS``
         and the ``BASIS_PAYLOAD`` docstring). A wide tolerance is fine - we're
@@ -112,7 +126,8 @@ class TestDesignIntent:
             f"payload_to_vector."
         )
 
-    def test_doubling_steps_roughly_scales_kudos(self, kudos_model, basis_payload):
+    def test_doubling_steps_roughly_scales_kudos(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """Doubling the step count roughly scales kudos within a 1.4-2.5x band."""
         baseline = kudos_model.calculate_kudos(basis_payload)
         doubled = dict(basis_payload, steps=basis_payload["steps"] * 2)
         doubled_kudos = kudos_model.calculate_kudos(doubled)
@@ -122,7 +137,8 @@ class TestDesignIntent:
         ratio = doubled_kudos / baseline
         assert 1.4 <= ratio <= 2.5, f"Doubling steps changed kudos by ratio {ratio:.2f}; expected 1.4..2.5"
 
-    def test_doubling_resolution_increases_kudos(self, kudos_model, basis_payload):
+    def test_doubling_resolution_increases_kudos(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """Quadrupling the pixel count strictly increases kudos."""
         baseline = kudos_model.calculate_kudos(basis_payload)
         bigger = dict(basis_payload, width=1024, height=1024)
         bigger_kudos = kudos_model.calculate_kudos(bigger)
@@ -141,32 +157,37 @@ class TestPostInferenceArithmetic:
     explicitly so the arithmetic relationships are unambiguous.
     """
 
-    def test_basis_adjustment_adds_before_scaling(self, kudos_model, basis_payload):
+    def test_basis_adjustment_adds_before_scaling(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """``basis_adjustment`` is added to KUDOS_BASIS before scaling."""
         # Clean baseline: adjustment=0 isolates the model's job_ratio * 10 path.
         baseline_unadjusted = kudos_model.calculate_kudos(basis_payload, basis_adjustment=0)
         adjusted = kudos_model.calculate_kudos(basis_payload, basis_adjustment=5)
         # adjusted / baseline_unadjusted == (10+5)/10 == 1.5
         assert adjusted == pytest.approx(baseline_unadjusted * 1.5, rel=0.01)
 
-    def test_basis_scale_multiplies(self, kudos_model, basis_payload):
+    def test_basis_scale_multiplies(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """``basis_scale`` multiplies the post-adjustment kudos."""
         baseline = kudos_model.calculate_kudos(basis_payload, basis_adjustment=0)
         scaled = kudos_model.calculate_kudos(basis_payload, basis_adjustment=0, basis_scale=1.25)
         assert scaled == pytest.approx(baseline * 1.25, rel=0.01)
 
-    def test_zero_scale_zeroes_kudos(self, kudos_model, basis_payload):
+    def test_zero_scale_zeroes_kudos(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """A zero ``basis_scale`` zeroes the kudos price."""
         assert kudos_model.calculate_kudos(basis_payload, basis_scale=0) == 0.0
 
-    def test_combined_adjustment_and_scale(self, kudos_model, basis_payload):
+    def test_combined_adjustment_and_scale(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """Adjustment and scale compose as ``(basis + adjustment) * scale``."""
         baseline_unadjusted = kudos_model.calculate_kudos(basis_payload, basis_adjustment=0)
         # (10 + 5) * 1.25 / 10 == 1.875
         combined = kudos_model.calculate_kudos(basis_payload, basis_adjustment=5, basis_scale=1.25)
         assert combined == pytest.approx(baseline_unadjusted * 1.875, rel=0.01)
 
-    def test_default_adjustment_is_one(self, kudos_model, basis_payload):
-        """Documented behaviour: the default ``basis_adjustment`` is 1, so an
-        unadorned ``calculate_kudos(payload)`` returns 110% of the model's
-        raw output. Locked in here because changing the default would silently
-        re-price every job in the system."""
+    def test_default_adjustment_is_one(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """The default ``basis_adjustment`` of 1 returns 110% of the model's raw output.
+
+        Locked in here because changing the default would silently re-price every
+        job in the system.
+        """
         unadjusted = kudos_model.calculate_kudos(basis_payload, basis_adjustment=0)
         defaulted = kudos_model.calculate_kudos(basis_payload)
         assert defaulted == pytest.approx(unadjusted * 11.0 / 10.0, rel=0.01)
@@ -175,13 +196,15 @@ class TestPostInferenceArithmetic:
 class TestUnknownInputsHandled:
     """Unknown samplers / control types should not crash, they get sane defaults."""
 
-    def test_unknown_sampler_falls_back_to_k_euler(self, kudos_model, basis_payload):
+    def test_unknown_sampler_falls_back_to_k_euler(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """An unknown sampler name falls back to a default and still prices positively."""
         unknown = dict(basis_payload, sampler_name="not_a_real_sampler_xyz")
         # Should not raise, and should produce a finite kudos value.
         kudos = kudos_model.calculate_kudos(unknown)
         assert kudos > 0
 
-    def test_remix_source_processing_treated_as_img2img(self, kudos_model, basis_payload):
+    def test_remix_source_processing_treated_as_img2img(self, kudos_model: KudosModel, basis_payload: dict[str, Any]) -> None:
+        """A ``remix`` source_processing prices identically to ``img2img``."""
         # See the "Little hack until new model is out" comment in
         # payload_to_vector: source_processing="remix" is mapped to "img2img".
         remix = dict(basis_payload, source_processing="remix", source_image=True)

--- a/tests/unit/test_kudos_settlement.py
+++ b/tests/unit/test_kudos_settlement.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: 2026 Tazlin
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Characterization of request settlement and contribution accounting.
+
+Covers the kudos movements that settle a completed job: the requester is debited
+for usage, the contributing worker and its owner are credited, and the +2
+style-owner credit is applied on styled generations. While a worker's owner is
+untrusted, half of every contribution credit is held in an evaluation escrow
+(``evaluating_kudos``) rather than the spendable balance; once that escrow
+crosses the trust threshold it is flushed into the balance and the owner becomes
+trusted. A censored generation debits the requester nothing.
+
+The image pop/submit HTTP lifecycle depends on S3-compatible object storage, so
+settlement is characterized against the real ``record_usage`` and
+``record_contribution`` primitives on a persisted ORM graph rather than driven
+end to end over HTTP.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.orm import Session
+
+from horde.classes.base.processing_generation import ProcessingGeneration
+from horde.classes.base.user import User, UserRole
+from horde.classes.base.worker import WorkerTemplate
+from horde.enums import UserRoleTypes
+from tests.fixture_types import MakeUser, MakeUserRole
+
+
+def _make_worker(db_session: Session, owner: User) -> WorkerTemplate:
+    """Create a persisted generic worker owned by the given user."""
+    worker = WorkerTemplate(name=f"worker_{uuid.uuid4().hex[:12]}", user_id=owner.id)
+    db_session.add(worker)
+    db_session.flush()
+    return worker
+
+
+class TestRequesterDebit:
+    """Usage debits the requester by the charged amount."""
+
+    def test_usage_debits_requester_balance(self, db_session: Session, make_user: MakeUser) -> None:
+        """Recorded usage lowers the requester's balance by the charged kudos."""
+        user = make_user(kudos=1000)
+        user.record_usage(raw_things=10, kudos=50, usage_type="image")
+        assert user.kudos == 950
+
+    def test_horde_tax_debit_uses_the_same_path(self, db_session: Session, make_user: MakeUser) -> None:
+        """The up-front horde tax debits through the same usage path as ordinary usage."""
+        user = make_user(kudos=1000)
+        user.record_usage(raw_things=0, kudos=1, usage_type="image")
+        assert user.kudos == 999
+
+    def test_usage_debit_respects_the_floor(self, db_session: Session, make_user: MakeUser) -> None:
+        """A usage debit cannot push the requester below the user-class floor."""
+        user = make_user(kudos=30)
+        user.record_usage(raw_things=0, kudos=1000, usage_type="image")
+        assert user.kudos == 25
+
+
+class TestCensoredDebit:
+    """A censored generation charges the requester nothing."""
+
+    def test_censored_generation_debits_zero(self) -> None:
+        """A censored generation resolves to a zero requester debit."""
+        # adjust_user_kudos reads only ``self.censored``; a SimpleNamespace is a
+        # deliberate duck-typed stand-in for the ORM ``self``, so pyrefly's
+        # self-type check is suppressed here and below.
+        censored = SimpleNamespace(censored=True)
+        assert ProcessingGeneration.adjust_user_kudos(censored, 100) == 0  # type: ignore
+
+    def test_uncensored_generation_debits_full_amount(self) -> None:
+        """An uncensored generation debits the full charged amount."""
+        uncensored = SimpleNamespace(censored=False)
+        assert ProcessingGeneration.adjust_user_kudos(uncensored, 100) == 100  # type: ignore
+
+
+class TestStyleOwnerCredit:
+    """A styled generation credits the style owner a fixed +2."""
+
+    def test_style_credit_adds_two_kudos(self, db_session: Session, make_user: MakeUser) -> None:
+        """Recording a style credits the owner two kudos."""
+        owner = make_user(kudos=1000)
+        owner.record_style(2, "image")
+        assert owner.kudos == 1002
+
+
+class TestWorkerContributionCredit:
+    """A contribution credits the worker and its owner."""
+
+    def test_trusted_owner_receives_full_credit_on_balance(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """A trusted owner receives the whole contribution credit on the spendable balance."""
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        worker = _make_worker(db_session, owner)
+
+        worker.record_contribution(raw_things=1000, kudos=100, things_per_sec=1)
+        db_session.commit()
+
+        assert worker.kudos == 100
+        assert owner.kudos == 1100
+        assert owner.evaluating_kudos == 0
+
+    def test_worker_credit_scales_with_bridge_multiplier(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The bridge multiplier scales both the worker and owner contribution credit."""
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        worker = _make_worker(db_session, owner)
+        monkeypatch.setattr(type(worker), "get_bridge_kudos_multiplier", lambda self: 2)
+
+        worker.record_contribution(raw_things=1000, kudos=100, things_per_sec=1)
+        db_session.commit()
+
+        assert worker.kudos == 200
+        assert owner.kudos == 1200
+
+
+class TestUntrustedEscrowSplit:
+    """While untrusted, half of a contribution credit is held in escrow."""
+
+    def test_half_of_credit_goes_to_escrow(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An untrusted owner's contribution credit splits evenly between balance and escrow."""
+        # A fresh account is not yet trusted, so half its contribution credit is
+        # withheld for evaluation and half reaches the spendable balance. The
+        # escrow stays below the trust threshold, so no promotion occurs.
+        monkeypatch.setenv("KUDOS_TRUST_THRESHOLD", "100000")
+        owner = make_user(kudos=1000)
+        worker = _make_worker(db_session, owner)
+
+        worker.record_contribution(raw_things=1000, kudos=100, things_per_sec=1)
+        db_session.commit()
+
+        assert owner.kudos == 1050
+        assert owner.evaluating_kudos == 50
+        # The worker itself is always credited the full contribution.
+        assert worker.kudos == 100
+
+    def test_anonymous_owner_is_not_escrowed(self, db_session: Session, make_user: MakeUser) -> None:
+        """An anonymous owner receives the whole contribution credit on the balance."""
+        anon = make_user(username="Anonymous", oauth_id="anon", kudos=1000)
+        worker = _make_worker(db_session, anon)
+
+        worker.record_contribution(raw_things=1000, kudos=100, things_per_sec=1)
+        db_session.commit()
+
+        assert anon.kudos == 1100
+        assert anon.evaluating_kudos == 0
+
+
+class TestTrustPromotion:
+    """Crossing the trust threshold flushes escrow into the balance."""
+
+    def test_escrow_flush_credits_balance_and_grants_trust(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Crossing the threshold empties escrow into the balance and records a trusted role."""
+        monkeypatch.setenv("KUDOS_TRUST_THRESHOLD", "100")
+        owner = make_user(kudos=1000, created=datetime.utcnow() - timedelta(days=8))
+        owner.evaluating_kudos = 250
+        db_session.flush()
+
+        owner.check_for_trust()
+
+        assert owner.evaluating_kudos == 0
+        assert owner.kudos == 1250
+        # The owner is now trusted: a committed TRUSTED role records the promotion.
+        db_session.refresh(owner)
+        assert owner.trusted is True
+        role = db_session.query(UserRole).filter_by(user_id=owner.id, user_role=UserRoleTypes.TRUSTED).first()
+        assert role is not None and role.value is True
+
+    def test_escrow_below_threshold_is_not_promoted(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Escrow below the threshold stays escrowed and grants no trust."""
+        monkeypatch.setenv("KUDOS_TRUST_THRESHOLD", "100")
+        owner = make_user(kudos=1000, created=datetime.utcnow() - timedelta(days=8))
+        owner.evaluating_kudos = 50
+        db_session.flush()
+
+        owner.check_for_trust()
+
+        assert owner.evaluating_kudos == 50
+        assert owner.kudos == 1000
+        assert owner.trusted is False
+
+    def test_young_account_is_not_promoted(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An account younger than a week is not promoted even with sufficient escrow."""
+        # Promotion requires the account to have existed for at least a week.
+        monkeypatch.setenv("KUDOS_TRUST_THRESHOLD", "100")
+        owner = make_user(kudos=1000, created=datetime.utcnow() - timedelta(days=2))
+        owner.evaluating_kudos = 250
+        db_session.flush()
+
+        owner.check_for_trust()
+
+        assert owner.evaluating_kudos == 250
+        assert owner.trusted is False

--- a/tests/unit/test_kudos_uptime.py
+++ b/tests/unit/test_kudos_uptime.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2026 Tazlin
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Characterization of the worker uptime reward.
+
+A worker that stays online accrues uptime, and each time its accrued uptime
+crosses the reward threshold both the worker and the worker's owner are credited
+the uptime reward. The owner's share follows the same trust routing as any
+credit: a trusted (or anonymous) owner receives it on the spendable balance,
+while an untrusted owner's share is held in the evaluation escrow.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+
+from horde.classes.base.user import User
+from horde.classes.base.worker import WorkerTemplate
+from horde.enums import UserRoleTypes
+from tests.fixture_types import MakeUser, MakeUserRole
+
+# The base uptime reward for a generic worker (WorkerTemplate.calculate_uptime_reward).
+BASE_UPTIME_REWARD: int = 100
+
+
+@pytest.fixture(autouse=True)
+def _trust_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    # record_uptime consults the trust threshold for untrusted owners; pin it high
+    # so escrow accrual is observed without triggering an automatic promotion.
+    monkeypatch.setenv("KUDOS_TRUST_THRESHOLD", "100000")
+
+
+def _make_worker(db_session: Session, owner: User, *, primed_to_cross: bool = False) -> WorkerTemplate:
+    """Create a persisted worker, optionally primed to cross the uptime reward threshold on the next check-in."""
+    worker = WorkerTemplate(name=f"worker_{uuid.uuid4().hex[:12]}", user_id=owner.id)
+    db_session.add(worker)
+    db_session.flush()
+    if primed_to_cross:
+        # A recent check-in (past the 30s debounce, within the 300s staleness
+        # window) whose accrued uptime lands just under the reward threshold, so
+        # this check-in tips it over.
+        worker.last_check_in = datetime.utcnow() - timedelta(seconds=40)
+        worker.uptime = worker.uptime_reward_threshold - 10
+        worker.last_reward_uptime = 0
+    db_session.flush()
+    return worker
+
+
+class TestUptimeRewardCrossing:
+    """Crossing the uptime threshold credits both the worker and its owner."""
+
+    def test_trusted_owner_credited_on_balance(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """A trusted owner is credited the reward on the spendable balance."""
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        worker = _make_worker(db_session, owner, primed_to_cross=True)
+
+        worker.check_in(ipaddr="10.0.0.1")
+
+        assert worker.kudos == BASE_UPTIME_REWARD
+        assert owner.kudos == 1000 + BASE_UPTIME_REWARD
+        assert owner.evaluating_kudos == 0
+
+    def test_untrusted_owner_share_goes_to_escrow(self, db_session: Session, make_user: MakeUser) -> None:
+        """An untrusted owner's reward is held in escrow while the worker is still credited."""
+        owner = make_user(kudos=1000)
+        worker = _make_worker(db_session, owner, primed_to_cross=True)
+
+        worker.check_in(ipaddr="10.0.0.1")
+
+        # The worker is always credited, but the untrusted owner's share is held
+        # for evaluation rather than reaching the spendable balance.
+        assert worker.kudos == BASE_UPTIME_REWARD
+        assert owner.kudos == 1000
+        assert owner.evaluating_kudos == BASE_UPTIME_REWARD
+
+    def test_no_reward_before_threshold_is_crossed(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """Uptime short of the threshold credits neither the worker nor the owner."""
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        worker = _make_worker(db_session, owner)
+        worker.last_check_in = datetime.utcnow() - timedelta(seconds=40)
+        worker.uptime = 0
+        worker.last_reward_uptime = 0
+        db_session.flush()
+
+        worker.check_in(ipaddr="10.0.0.1")
+
+        assert worker.kudos == 0
+        assert owner.kudos == 1000
+
+
+class TestUptimeOwnerRouting:
+    """``record_uptime`` routes the owner credit by trust state."""
+
+    def test_trusted_owner_credited_on_balance(
+        self,
+        db_session: Session,
+        make_user: MakeUser,
+        make_user_role: MakeUserRole,
+    ) -> None:
+        """A trusted owner's uptime credit lands on the spendable balance."""
+        owner = make_user(kudos=1000)
+        make_user_role(owner, UserRoleTypes.TRUSTED)
+        owner.record_uptime(100)
+        assert owner.kudos == 1100
+        assert owner.evaluating_kudos == 0
+
+    def test_untrusted_owner_credited_to_escrow(self, db_session: Session, make_user: MakeUser) -> None:
+        """An untrusted owner's uptime credit lands in the evaluation escrow."""
+        owner = make_user(kudos=1000)
+        owner.record_uptime(100)
+        assert owner.kudos == 1000
+        assert owner.evaluating_kudos == 100
+
+    def test_anonymous_owner_credited_on_balance(self, db_session: Session, make_user: MakeUser) -> None:
+        """An anonymous owner's uptime credit lands on the spendable balance."""
+        anon = make_user(username="Anonymous", oauth_id="anon", kudos=1000)
+        anon.record_uptime(100)
+        assert anon.kudos == 1100
+        assert anon.evaluating_kudos == 0
+
+    def test_bypass_credits_balance_despite_untrusted(self, db_session: Session, make_user: MakeUser) -> None:
+        """The evaluation bypass credits the balance even for an untrusted owner."""
+        owner = make_user(kudos=1000)
+        owner.record_uptime(100, bypass_eval=True)
+        assert owner.kudos == 1100
+        assert owner.evaluating_kudos == 0

--- a/uv.lock
+++ b/uv.lock
@@ -59,6 +59,7 @@ dev = [
     { name = "ruff" },
     { name = "testcontainers", extra = ["redis"] },
     { name = "tox" },
+    { name = "types-python-dateutil" },
 ]
 telemetry-profiling = [
     { name = "pyroscope-io" },
@@ -119,6 +120,7 @@ dev = [
     { name = "ruff", specifier = "==0.15.12" },
     { name = "testcontainers", extras = ["postgres", "redis"] },
     { name = "tox", specifier = "~=4.14.1" },
+    { name = "types-python-dateutil", specifier = ">=2.9.0.20260716" },
 ]
 telemetry-profiling = [
     { name = "pyroscope-io" },
@@ -2532,6 +2534,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/e2/98cbdadaa14d53b0f37ffcf4cbb1652ffb21f8b2f300e43f17167136af1c/tox-4.14.2.tar.gz", hash = "sha256:0defb44f6dafd911b61788325741cc6b2e12ea71f987ac025ad4d649f1f1a104", size = 178515, upload-time = "2024-03-22T15:44:45.756Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/7e/496c1b338a9ef244a03a654fcb9e922c37a9c547d00e73f99f3a94ac838e/tox-4.14.2-py3-none-any.whl", hash = "sha256:2900c4eb7b716af4a928a7fdc2ed248ad6575294ed7cfae2ea41203937422847", size = 155382, upload-time = "2024-03-22T15:44:43.079Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260716"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/9a/aefb9f80ff79641d36149352afe66ca835c5e6894deb518418f786f4b8ad/types_python_dateutil-2.9.0.20260716.tar.gz", hash = "sha256:1d55d1c3024bdb4861bb6a6622c9ec800c433d87bdc5b16fb84cdd0eed4ef2cb", size = 17516, upload-time = "2026-07-16T04:48:06.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/85/cff97326a81e7e8877803e78e3ea56c840b85bb811934b9c936f7c40f185/types_python_dateutil-2.9.0.20260716-py3-none-any.whl", hash = "sha256:1ae41d51a5c5f6bbeeb7f1f34df7086d55ff1605cf88d2ed71a7a276e1a7794e", size = 18443, upload-time = "2026-07-16T04:48:05.793Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds tests that pin the current kudos semantics of every kudos-moving flow in the horde, before soon-to-be PR'd changes rewrite the mutation machinery underneath them.

Three of the tests are xfail, documenting identified defects (a problem with interrogation-uptime double-credit, and an unreachable cancel-settle).

### The tests
#### Unit tier (persisted ORM graphs, Postgres via fixtures):

- `test_kudos_balance.py`: `User.modify_kudos` / `Worker.modify_kudos` and the per-user-class balance floor.
- `test_kudos_settlement.py`: requester debit, worker/owner credit with bridge multiplier, +2 style credit, censored zero-debit, untrusted half-escrow split, trust promotion.
- `test_kudos_uptime.py`: uptime reward crossing credits worker and owner with trust-routed escrow/balance split.
- `test_kudos_image_cancel.py`: cancelling an in-flight image generation settles like a submission; completed/faulted generations settle nothing.
- `test_kudos_interrogation.py`: interrogation form settlement including the burn.
- `test_kudos_monthly.py`: monthly entitlements, immediate diff-credit on change, one-month cursor advance, per-period idempotency.
- `test_kudos_invariants.py`: the three strict-xfail intended contracts (below).

#### Integration tier (in-process Flask client):

- `test_kudos_request_activation.py`: up-front horde tax at activation for registered and anon users, priority seeded from balance, upfront-kudos gate refusal charges nothing.
- `test_kudos_aesthetics.py`: 5 kudos per rating, capped at `consumed_kudos - 1`.
- `test_kudos_endpoints.py`: transfer (audit log, anon-source rejection, shared-key credit), privileged award, admin adjust, dead-code guard for `KoboldKudosTransfer`.

### The xfails

https://github.com/Haidra-Org/AI-Horde/blob/d380d74c74b3c22f02bbe5ba692b25614bedd809/tests/unit/test_kudos_invariants.py#L80-L120

- One interrogation-uptime crossing for an untrusted owner should credit exactly the reward, once. Today the alchemist override credits both balance and escrow, doubling the gain.
- `form.cancel()` on a still-PROCESSING interrogation form should settle like a submit. Today the state flips before the settle check, so the settle call is unreachable.

### Ruff format catchup
Includes some incidental formatting fixes that have drifted in. All the changes in non-test files are whitespace/formatting only.

### Test typing
Modifies a number of the fixtures used by these tests to have accurate type hints, as part of my on going effort to incrementally introduce better static analyzability.

### Test plan

This PR is the test plan. On this branch: 340 passed, 3 xfailed, unit + integration, Postgres + fakeredis via fixtures.

### Review touch points

- The flows are characterized against persisted ORM graphs rather than full HTTP because the full path drags in S3-dependent submit machinery.
- Amounts asserted are the current production semantics, including oddities (the +2 style credit, the burn values). Where a number looks wrong, that is the point: the suite pins the status-quo, and intended-contract changes can come later if needed. 
    - I do think that alchemy likely *should* be getting additional uptime kudos, but the as-is semantic seems accidental rather than intended.
